### PR TITLE
fix: initialize pubKeyCount on fallback profiles

### DIFF
--- a/chain-api/src/types/UserProfile.ts
+++ b/chain-api/src/types/UserProfile.ts
@@ -66,7 +66,7 @@ export class UserProfile extends ChainObject {
   })
   @IsInt()
   @Min(0)
-  pubKeyCount: number;
+  pubKeyCount = 0;
 }
 
 export const UP_INDEX_KEY = "GCUP";

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -85,6 +85,8 @@ export class PublicKeyService {
       obj.ethAddress = address;
     }
 
+    obj.pubKeyCount = 1;
+
     const data = Buffer.from(obj.serialize());
     await ctx.stub.putState(key, data);
   }
@@ -94,7 +96,8 @@ export class PublicKeyService {
     const userProfile = await createValidChainObject(UserProfile, {
       alias: asValidUserAlias(`client|invalidated`),
       ethAddress: "0000000000000000000000000000000000000000",
-      roles: []
+      roles: [],
+      pubKeyCount: 0
     });
 
     const data = Buffer.from(userProfile.serialize());
@@ -147,6 +150,7 @@ export class PublicKeyService {
         adminProfile.ethAddress = adminEthAddress;
         adminProfile.alias = alias;
         adminProfile.roles = Array.from(UserProfile.ADMIN_ROLES);
+        adminProfile.pubKeyCount = 0;
 
         return adminProfile as UserProfileWithRoles;
       }
@@ -162,6 +166,7 @@ export class PublicKeyService {
     profile.ethAddress = signing === SigningScheme.ETH ? address : undefined;
     profile.tonAddress = signing === SigningScheme.TON ? address : undefined;
     profile.roles = Array.from(UserProfile.DEFAULT_ROLES);
+    profile.pubKeyCount = 0;
     return profile as UserProfileWithRoles;
   }
 

--- a/chaincode/src/types/GalaChainContext.ts
+++ b/chaincode/src/types/GalaChainContext.ts
@@ -104,6 +104,7 @@ export class GalaChainContext extends Context {
     profile.ethAddress = this.callingUserEthAddressValue;
     profile.tonAddress = this.callingUserTonAddressValue;
     profile.roles = this.callingUserRoles;
+    profile.pubKeyCount = 0;
     return profile;
   }
 


### PR DESCRIPTION
## Summary
- default pubKeyCount to 0 on UserProfile
- initialize pubKeyCount in PublicKeyService and GalaChainContext

## Testing
- `CI=1 npx nx test chain-api`
- `CI=1 npx nx test chaincode` *(fails: Module "./types" has already exported a member named 'randomUniqueKey')*
- `CI=1 npx nx lint chain-api` *(fails: 2 errors in chain-api/src/utils/signatures/ton.ts)*
- `CI=1 npx nx lint chaincode`


------
https://chatgpt.com/codex/tasks/task_e_68b71cf80a0483309ba15e2d7f6a86dc