### PR TITLE
fix: enforce signature threshold for multi-key auth

### DIFF
--- a/chaincode/src/services/PublicKeyService.spec.ts
+++ b/chaincode/src/services/PublicKeyService.spec.ts
@@ -12,7 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  ChainCallDTO,
+  PublicKey,
+  SigningScheme,
+  signatures
+} from "@gala-chain/api";
 import { PublicKeyService } from "./PublicKeyService";
+import { PkInvalidSignatureError } from "./PublicKeyError";
 
 it(`should normalize secp256k1 public key`, async () => {
   // Given
@@ -54,4 +61,48 @@ it(`should normalize secp256k1 public key`, async () => {
   expect(keyFromHex0x).toEqual(inputBase64Compressed);
   expect(await fails1.catch((e) => e.message)).toEqual(expect.stringContaining("Cannot normalize secp256k1"));
   expect(await fails2.catch((e) => e.message)).toEqual(expect.stringContaining("Unknown point format"));
+});
+
+describe(`ensurePublicKeySignatureIsValid`, () => {
+  const ctx: unknown = {};
+  const userId = "user";
+
+  it(`should fail when not enough valid signatures`, async () => {
+    const pair1 = signatures.genKeyPair();
+    const pair2 = signatures.genKeyPair();
+
+    const pk = new PublicKey();
+    pk.publicKeys = [pair1.publicKey, pair2.publicKey];
+    pk.requiredSignatures = 2;
+    pk.signing = SigningScheme.ETH;
+
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue(pk);
+
+    const dto = new ChainCallDTO();
+    dto.sign(pair1.privateKey);
+
+    await expect(
+      PublicKeyService.ensurePublicKeySignatureIsValid(ctx as any, userId, dto)
+    ).rejects.toBeInstanceOf(PkInvalidSignatureError);
+  });
+
+  it(`should succeed when enough valid signatures are provided`, async () => {
+    const pair1 = signatures.genKeyPair();
+    const pair2 = signatures.genKeyPair();
+
+    const pk = new PublicKey();
+    pk.publicKeys = [pair1.publicKey, pair2.publicKey];
+    pk.requiredSignatures = 2;
+    pk.signing = SigningScheme.ETH;
+
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue(pk);
+
+    const dto = new ChainCallDTO();
+    dto.sign(pair1.privateKey);
+    dto.sign(pair2.privateKey);
+
+    await expect(
+      PublicKeyService.ensurePublicKeySignatureIsValid(ctx as any, userId, dto)
+    ).resolves.toEqual(pk);
+  });
 });

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -26,7 +26,8 @@ import {
   asValidUserAlias,
   createValidChainObject,
   normalizePublicKeys,
-  signatures
+  signatures,
+  SignatureDto
 } from "@gala-chain/api";
 import { Context } from "fabric-contract-api";
 
@@ -218,10 +219,40 @@ export class PublicKeyService {
     if (pk === undefined) {
       throw new PkMissingError(userId);
     }
+    const signaturesList: SignatureDto[] =
+      dto.signatures && dto.signatures.length > 0
+        ? dto.signatures
+        : [
+            {
+              signature: dto.signature ?? "",
+              prefix: dto.prefix,
+              signerAddress: dto.signerAddress,
+              signerPublicKey: dto.signerPublicKey,
+              signing: dto.signing
+            }
+          ];
 
-    const isSignatureValid = pk.publicKeys.some((key) => dto.isSignatureValid(key));
+    const validKeys = new Set<string>();
 
-    if (!isSignatureValid) {
+    for (const sig of signaturesList) {
+      for (const key of pk.publicKeys) {
+        const isValid =
+          (sig.signing ?? pk.signing) === SigningScheme.TON
+            ? signatures.ton.isValidSignature(
+                Buffer.from(sig.signature ?? "", "base64"),
+                dto,
+                Buffer.from(key, "base64"),
+                sig.prefix
+              )
+            : signatures.isValid(sig.signature ?? "", dto, key);
+
+        if (isValid) {
+          validKeys.add(key);
+        }
+      }
+    }
+
+    if (validKeys.size < pk.requiredSignatures) {
       throw new PkInvalidSignatureError(userId);
     }
 


### PR DESCRIPTION
## Summary
- verify DTO signatures against required public key threshold
- cover signature threshold validation with unit tests

## Testing
- `npx -y nx@21.4.1 test chaincode` *(fails: Could not find Nx modules)*
- `npx -y jest chaincode/src/services/PublicKeyService.spec.ts` *(fails: Cannot find package '@nx/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b73594254c833081ba2b486ed7da3b