### PR TITLE
feat: track user signature requirements

### DIFF
--- a/chain-api/src/types/UserProfile.ts
+++ b/chain-api/src/types/UserProfile.ts
@@ -12,7 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IsNotEmpty, IsOptional, IsString, ValidateIf } from "class-validator";
+import {
+  ArrayNotEmpty,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Min,
+  ValidateIf
+} from "class-validator";
 import { JSONSchema } from "class-validator-jsonschema";
 
 import { IsUserAlias } from "../validators";
@@ -57,11 +64,29 @@ export class UserProfile extends ChainObject {
       .sort()
       .join(", ")}, but you can use arbitrary strings to define your own roles.`
   })
-  @IsOptional()
   @IsString({ each: true })
-  roles?: string[];
+  @ArrayNotEmpty()
+  roles: string[];
+
+  @JSONSchema({
+    description: `Number of stored public keys for the user.`
+  })
+  @IsInt()
+  @Min(0)
+  pubKeyCount: number;
+
+  @JSONSchema({
+    description: `Minimum number of signatures required for authorization.`
+  })
+  @IsInt()
+  @Min(1)
+  requiredSignatures: number;
 }
 
 export const UP_INDEX_KEY = "GCUP";
 
-export type UserProfileWithRoles = UserProfile & { roles: string[] };
+export type UserProfileWithRoles = UserProfile & {
+  roles: string[];
+  pubKeyCount: number;
+  requiredSignatures: number;
+};

--- a/chain-test/src/unit/fixture.ts
+++ b/chain-test/src/unit/fixture.ts
@@ -89,6 +89,8 @@ interface CallingUserData {
   ethAddress?: string;
   tonAddress?: string;
   roles: string[];
+  pubKeyCount?: number;
+  requiredSignatures?: number;
 }
 
 /**
@@ -236,7 +238,13 @@ class Fixture<Ctx extends TestGalaChainContext, T extends GalaContract<Ctx>> {
 
     const userProfiles = users.map((u) => ({
       key: `\u0000GCUP\u0000${u.ethAddress}\u0000`,
-      value: JSON.stringify({ alias: u.identityKey, ethAddress: u.ethAddress, roles: u.roles })
+      value: JSON.stringify({
+        alias: u.identityKey,
+        ethAddress: u.ethAddress,
+        roles: u.roles,
+        pubKeyCount: 1,
+        requiredSignatures: 1
+      })
     }));
 
     return this.savedKVState(...publicKeys, ...userProfiles);
@@ -259,15 +267,24 @@ class Fixture<Ctx extends TestGalaChainContext, T extends GalaContract<Ctx>> {
    *
    * @param user - User data with identity, addresses, and roles
    * @returns This fixture instance for method chaining
-   */
+  */
   callingUser(
-    user: ChainUserWithRoles | { alias: UserAlias; ethAddress?: string; tonAddress?: string; roles: string[] }
+    user: ChainUserWithRoles | {
+      alias: UserAlias;
+      ethAddress?: string;
+      tonAddress?: string;
+      roles: string[];
+      pubKeyCount?: number;
+      requiredSignatures?: number;
+    }
   ): Fixture<Ctx, T> {
     if ("identityKey" in user) {
       this.ctx.callingUserData = {
         alias: user.identityKey,
         ethAddress: user.ethAddress,
-        roles: user.roles
+        roles: user.roles,
+        pubKeyCount: 1,
+        requiredSignatures: 1
       };
       return this;
     }

--- a/chaincode/src/contracts/PublicKeyContract.spec.ts
+++ b/chaincode/src/contracts/PublicKeyContract.spec.ts
@@ -545,7 +545,9 @@ describe("GetMyProfile", () => {
       transactionSuccess({
         alias: user.alias,
         ethAddress: user.ethAddress,
-        roles: [UserRole.EVALUATE, UserRole.SUBMIT]
+        roles: [UserRole.EVALUATE, UserRole.SUBMIT],
+        pubKeyCount: 1,
+        requiredSignatures: 1
       })
     );
     expect(resp2).toEqual(resp1);
@@ -576,7 +578,9 @@ describe("GetMyProfile", () => {
       transactionSuccess({
         alias: user.alias,
         tonAddress: user.tonAddress,
-        roles: UserProfile.DEFAULT_ROLES
+        roles: UserProfile.DEFAULT_ROLES,
+        pubKeyCount: 1,
+        requiredSignatures: 1
       })
     );
     expect(resp2).toEqual(resp1);

--- a/chaincode/src/contracts/authenticate.eth.spec.ts
+++ b/chaincode/src/contracts/authenticate.eth.spec.ts
@@ -68,7 +68,9 @@ const Success = labeled<Expectation>("Success")((response, user) => {
     transactionSuccess({
       alias: user.alias,
       ethAddress: user.ethAddress,
-      roles: UserProfile.DEFAULT_ROLES
+      roles: UserProfile.DEFAULT_ROLES,
+      pubKeyCount: 1,
+      requiredSignatures: 1
     })
   );
 });
@@ -78,7 +80,9 @@ const SuccessNoCustomAlias = labeled<Expectation>("SuccessNoCustomAlias")((respo
     transactionSuccess({
       alias: `eth|${user.ethAddress}`,
       ethAddress: user.ethAddress,
-      roles: UserProfile.DEFAULT_ROLES
+      roles: UserProfile.DEFAULT_ROLES,
+      pubKeyCount: 1,
+      requiredSignatures: 1
     })
   );
 });
@@ -88,7 +92,9 @@ const SuccessUnknownKey = labeled<Expectation>("SuccessUnknownKey")((response, u
     transactionSuccess({
       alias: expect.stringMatching(/^eth\|[a-fA-F0-9]{40}$/),
       ethAddress: expect.stringMatching(/^[a-fA-F0-9]{40}$/),
-      roles: UserProfile.DEFAULT_ROLES
+      roles: UserProfile.DEFAULT_ROLES,
+      pubKeyCount: 1,
+      requiredSignatures: 1
     })
   );
 });

--- a/chaincode/src/contracts/authenticate.ton.spec.ts
+++ b/chaincode/src/contracts/authenticate.ton.spec.ts
@@ -61,7 +61,9 @@ const Success = labeled<Expectation>("Success")((response, user) => {
     transactionSuccess({
       alias: user.alias,
       tonAddress: user.tonAddress,
-      roles: UserProfile.DEFAULT_ROLES
+      roles: UserProfile.DEFAULT_ROLES,
+      pubKeyCount: 1,
+      requiredSignatures: 1
     })
   );
 });

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -47,7 +47,12 @@ describe("authorization", () => {
     // Then
     expect(await f.signedCall()).toEqual(transactionSuccess(registeredUser));
     expect(await f.unsignedCall()).toEqual(
-      transactionSuccess({ alias: anonymousUserId, roles: [UserRole.EVALUATE] })
+      transactionSuccess({
+        alias: anonymousUserId,
+        roles: [UserRole.EVALUATE],
+        pubKeyCount: 1,
+        requiredSignatures: 1
+      })
     );
   });
 
@@ -71,7 +76,12 @@ describe("authorization", () => {
     // Then
     expect(await f1.signedCall()).toEqual(transactionSuccess(registeredUser));
     expect(await f1.unsignedCall()).toEqual(
-      transactionSuccess({ alias: anonymousUserId, roles: [UserRole.EVALUATE, UserRole.SUBMIT] })
+      transactionSuccess({
+        alias: anonymousUserId,
+        roles: [UserRole.EVALUATE, UserRole.SUBMIT],
+        pubKeyCount: 1,
+        requiredSignatures: 1
+      })
     );
 
     expect(await f2.signedCall()).toEqual(transactionErrorKey("ORGANIZATION_NOT_ALLOWED"));
@@ -94,7 +104,12 @@ describe("authorization", () => {
     // Then
     expect(await f1.signedCall()).toEqual(transactionSuccess(registeredUser));
     expect(await f1.unsignedCall()).toEqual(
-      transactionSuccess({ alias: anonymousUserId, roles: [UserRole.EVALUATE, UserRole.SUBMIT] })
+      transactionSuccess({
+        alias: anonymousUserId,
+        roles: [UserRole.EVALUATE, UserRole.SUBMIT],
+        pubKeyCount: 1,
+        requiredSignatures: 1
+      })
     );
 
     expect(await f2.signedCall()).toEqual(transactionErrorKey("ORGANIZATION_NOT_ALLOWED"));
@@ -120,7 +135,12 @@ describe("authorization", () => {
     expect(await f1.signedCall()).toEqual(transactionSuccess(registeredUser));
     expect(await f1.unsignedCall()).toEqual(
       // EVALUATE is default role for anonymous user (no signature)
-      transactionSuccess({ alias: anonymousUserId, roles: [UserRole.EVALUATE] })
+      transactionSuccess({
+        alias: anonymousUserId,
+        roles: [UserRole.EVALUATE],
+        pubKeyCount: 1,
+        requiredSignatures: 1
+      })
     );
 
     expect(await f2.signedCall()).toEqual(transactionSuccess(registeredUser));
@@ -180,7 +200,9 @@ describe("authorization", () => {
 
     const expectedUser = {
       alias: customUser.alias,
-      roles: UserProfile.DEFAULT_ROLES
+      roles: UserProfile.DEFAULT_ROLES,
+      pubKeyCount: 1,
+      requiredSignatures: 1
     };
 
     // When

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -97,9 +97,9 @@ export class PublicKeyService {
     const userProfile = await createValidChainObject(UserProfile, {
       alias: asValidUserAlias(`client|invalidated`),
       ethAddress: "0000000000000000000000000000000000000000",
-      roles: [],
+      roles: ["INVALIDATED"],
       pubKeyCount: 0,
-      requiredSignatures: 0
+      requiredSignatures: 1
     });
 
     const data = Buffer.from(userProfile.serialize());

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -84,6 +84,9 @@ export class PublicKeyService {
     } else {
       obj.ethAddress = address;
     }
+    obj.roles = Array.from(UserProfile.DEFAULT_ROLES);
+    obj.pubKeyCount = 1;
+    obj.requiredSignatures = 1;
 
     const data = Buffer.from(obj.serialize());
     await ctx.stub.putState(key, data);
@@ -94,7 +97,9 @@ export class PublicKeyService {
     const userProfile = await createValidChainObject(UserProfile, {
       alias: asValidUserAlias(`client|invalidated`),
       ethAddress: "0000000000000000000000000000000000000000",
-      roles: []
+      roles: [],
+      pubKeyCount: 0,
+      requiredSignatures: 0
     });
 
     const data = Buffer.from(userProfile.serialize());
@@ -119,6 +124,12 @@ export class PublicKeyService {
 
       if (userProfile.roles === undefined) {
         userProfile.roles = Array.from(UserProfile.DEFAULT_ROLES);
+      }
+      if (userProfile.pubKeyCount === undefined) {
+        userProfile.pubKeyCount = 1;
+      }
+      if (userProfile.requiredSignatures === undefined) {
+        userProfile.requiredSignatures = 1;
       }
 
       return userProfile as UserProfileWithRoles;
@@ -147,6 +158,8 @@ export class PublicKeyService {
         adminProfile.ethAddress = adminEthAddress;
         adminProfile.alias = alias;
         adminProfile.roles = Array.from(UserProfile.ADMIN_ROLES);
+        adminProfile.pubKeyCount = 1;
+        adminProfile.requiredSignatures = 1;
 
         return adminProfile as UserProfileWithRoles;
       }
@@ -162,6 +175,8 @@ export class PublicKeyService {
     profile.ethAddress = signing === SigningScheme.ETH ? address : undefined;
     profile.tonAddress = signing === SigningScheme.TON ? address : undefined;
     profile.roles = Array.from(UserProfile.DEFAULT_ROLES);
+    profile.pubKeyCount = 1;
+    profile.requiredSignatures = 1;
     return profile as UserProfileWithRoles;
   }
 

--- a/chaincode/src/types/GalaChainContext.ts
+++ b/chaincode/src/types/GalaChainContext.ts
@@ -49,6 +49,8 @@ export class GalaChainContext extends Context {
   private callingUserEthAddressValue?: string;
   private callingUserTonAddressValue?: string;
   private callingUserRolesValue?: string[];
+  private callingUserPubKeyCountValue?: number;
+  private callingUserRequiredSignaturesValue?: number;
   private txUnixTimeValue?: number;
   private loggerInstance?: GalaLoggerInstance;
 
@@ -104,16 +106,27 @@ export class GalaChainContext extends Context {
     profile.ethAddress = this.callingUserEthAddressValue;
     profile.tonAddress = this.callingUserTonAddressValue;
     profile.roles = this.callingUserRoles;
+    profile.pubKeyCount = this.callingUserPubKeyCountValue ?? 1;
+    profile.requiredSignatures = this.callingUserRequiredSignaturesValue ?? 1;
     return profile;
   }
 
-  set callingUserData(d: { alias?: UserAlias; ethAddress?: string; tonAddress?: string; roles: string[] }) {
+  set callingUserData(d: {
+    alias?: UserAlias;
+    ethAddress?: string;
+    tonAddress?: string;
+    roles: string[];
+    pubKeyCount?: number;
+    requiredSignatures?: number;
+  }) {
     if (this.callingUserValue !== undefined) {
       throw new Error("Calling user already set to " + this.callingUserValue);
     }
 
     this.callingUserValue = d.alias;
     this.callingUserRolesValue = d.roles ?? [UserRole.EVALUATE]; // default if `roles` is undefined
+    this.callingUserPubKeyCountValue = d.pubKeyCount ?? 1;
+    this.callingUserRequiredSignaturesValue = d.requiredSignatures ?? 1;
 
     if (d.ethAddress !== undefined) {
       this.callingUserEthAddressValue = d.ethAddress;
@@ -129,6 +142,8 @@ export class GalaChainContext extends Context {
     this.callingUserRolesValue = undefined;
     this.callingUserEthAddressValue = undefined;
     this.callingUserTonAddressValue = undefined;
+    this.callingUserPubKeyCountValue = undefined;
+    this.callingUserRequiredSignaturesValue = undefined;
   }
 
   public setDryRunOnBehalfOf(d: {
@@ -136,11 +151,15 @@ export class GalaChainContext extends Context {
     ethAddress?: string;
     tonAddress?: string;
     roles: string[];
+    pubKeyCount?: number;
+    requiredSignatures?: number;
   }): void {
     this.callingUserValue = d.alias;
     this.callingUserRolesValue = d.roles ?? [];
     this.callingUserEthAddressValue = d.ethAddress;
     this.callingUserTonAddressValue = d.tonAddress;
+    this.callingUserPubKeyCountValue = d.pubKeyCount ?? 1;
+    this.callingUserRequiredSignaturesValue = d.requiredSignatures ?? 1;
     this.isDryRun = true;
   }
 


### PR DESCRIPTION
## Summary
- require roles on user profiles and add pubKeyCount and requiredSignatures fields
- set default key and signature counts in PublicKeyService and context helpers
- adjust tests and fixtures for new profile structure

## Testing
- `npx nx run-many -t test -p chain-api,chaincode,chain-test` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8689dfd608330a4dd8a14b0bb9879