### PR TITLE
fix: ensure invalidated user profiles satisfy validation

### DIFF
--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -97,9 +97,9 @@ export class PublicKeyService {
     const userProfile = await createValidChainObject(UserProfile, {
       alias: asValidUserAlias(`client|invalidated`),
       ethAddress: "0000000000000000000000000000000000000000",
-      roles: [],
+      roles: ["INVALIDATED"],
       pubKeyCount: 0,
-      requiredSignatures: 0
+      requiredSignatures: 1
     });
 
     const data = Buffer.from(userProfile.serialize());


### PR DESCRIPTION
## Summary
- ensure invalidateUserProfile builds valid profile with placeholder role and signature count

## Testing
- `npx jest chaincode/src/services/PublicKeyService.spec.ts` *(fails: "@nx/jest" has no exported member named "getJestProjects")*

------
https://chatgpt.com/codex/tasks/task_e_68b8745d191c8330a7abc9e413d87e24