### PR TITLE
feat: support multiple public keys per user

### DIFF
--- a/chaincode/src/services/PublicKeyError.ts
+++ b/chaincode/src/services/PublicKeyError.ts
@@ -63,3 +63,17 @@ export class UserProfileNotFoundError extends NotFoundError {
     super(`UserProfile not found for user alias ${user}`, { user });
   }
 }
+
+export class PkDuplicateError extends ConflictError {
+  constructor(user: string) {
+    super(`Duplicate public keys provided for user ${user}`, { user });
+  }
+}
+
+export class PkCountMismatchError extends ConflictError {
+  constructor(user: string, provided: number, required: number) {
+    const msg =
+      `Required signatures (${required}) do not match available public keys (${provided}) for user ${user}`;
+    super(msg, { user, provided, required });
+  }
+}


### PR DESCRIPTION
## Summary
- support storing multiple public keys and required signature count
- guard against duplicate keys and invalid signature requirements
- ensure legacy single-key profiles migrate cleanly and add tests

## Testing
- `npx nx test chaincode --runInBand` *(failed: terminal emulator crashed)*
- `npx jest chaincode/src/contracts/PublicKeyContract.spec.ts --runInBand` *(failed: Jest: Failed to parse the TypeScript config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b89069a33083308495b7f8d807c765