### PR TITLE
feat: support multi-signature DTOs

### DIFF
--- a/chain-api/src/utils/generate-schema.spec.ts
+++ b/chain-api/src/utils/generate-schema.spec.ts
@@ -114,6 +114,44 @@ const expectedTestDtoSchema = {
       enum: ["ETH", "TON"],
       type: "string"
     },
+    signatures: {
+      description: "List of signatures for this DTO.",
+      items: {
+        properties: {
+          signature: {
+            description: expect.stringContaining(
+              "Signature of the DTO signed with caller's private key"
+            ),
+            minLength: 1,
+            type: "string"
+          },
+          signerPublicKey: {
+            description: "Public key of the user who signed the DTO.",
+            minLength: 1,
+            type: "string"
+          },
+          signerAddress: {
+            description: "Address of the user who signed the DTO. Typically Ethereum or TON address.",
+            minLength: 1,
+            type: "string"
+          },
+          prefix: {
+            description:
+              "Prefix for Metamask transaction signatures. Necessary to format payloads correctly to recover publicKey from web3 signatures.",
+            minLength: 1,
+            type: "string"
+          },
+          signing: {
+            description:
+              'Signing scheme used for the signature. "ETH" for Ethereum, and "TON" for The Open Network are supported. Default: "ETH".',
+            enum: ["ETH", "TON"],
+            type: "string"
+          }
+        },
+        type: "object"
+      },
+      type: "array"
+    },
     uniqueKey: {
       description:
         "Unique key of the DTO. It is used to prevent double execution of the same transaction on chain. " +


### PR DESCRIPTION
## Summary
- add SignatureDto and array-based signatures to ChainCallDTO
- support multiple signatures in sign/signed and validation helpers
- update schema and tests for new signature model

## Testing
- `npx nx test chain-api`

------
https://chatgpt.com/codex/tasks/task_e_68b89788f61483308ddfd780a920c16e