### PR TITLE
fix: respect signature's scheme and prefix

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -216,6 +216,20 @@ describe("ChainCallDTO", () => {
     expect(() => dto.sign(tonPair.secretKey.toString("base64"))).toThrow(ValidationFailedError);
   });
 
+  it("should validate signatures using stored signing params", () => {
+    const { privateKey } = genKeyPair();
+    const dto = new TestDto();
+    dto.prefix = "foo";
+    dto.amounts = [new BigNumber("1")];
+
+    dto.sign(privateKey);
+
+    dto.signing = SigningScheme.TON;
+    dto.prefix = "bar";
+
+    expect(dto.isSignatureValid(dto.signatures![0])).toEqual(true);
+  });
+
   it("should convert legacy single signature", () => {
     const dto = new TestDto();
     dto.signature = "legacy";

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -366,17 +366,29 @@ export class ChainCallDTO {
   public isSignatureValid(signatureOrPublicKey: string | SignatureDto, publicKey?: string): boolean {
     let signature: string;
     let pk: string | undefined;
+    let signing: SigningScheme | undefined;
+    let prefix = this.prefix;
+    let payloadSigning: SigningScheme | undefined;
 
     if (typeof signatureOrPublicKey === "object") {
       signature = signatureOrPublicKey.signature ?? "";
       pk = signatureOrPublicKey.signerPublicKey ?? publicKey;
+      signing = signatureOrPublicKey.signing;
+      payloadSigning = signatureOrPublicKey.signing;
+      prefix = signatureOrPublicKey.prefix ?? prefix;
     } else if (publicKey) {
       signature = signatureOrPublicKey;
       pk = publicKey;
+      signing = this.signing;
+      payloadSigning = this.signing;
     } else {
       signature = this.signature ?? "";
       pk = signatureOrPublicKey;
+      signing = this.signing;
+      payloadSigning = this.signing;
     }
+
+    signing = signing ?? SigningScheme.ETH;
 
     const payload = {
       ...this,
@@ -384,13 +396,14 @@ export class ChainCallDTO {
       signature: undefined,
       signerPublicKey: undefined,
       signerAddress: undefined,
-      prefix: undefined
+      prefix: undefined,
+      signing: payloadSigning
     };
 
-    if (this.signing === SigningScheme.TON) {
+    if (signing === SigningScheme.TON) {
       const signatureBuff = Buffer.from(signature ?? "", "base64");
       const publicKeyBuff = Buffer.from(pk ?? "", "base64");
-      return signatures.ton.isValidSignature(signatureBuff, payload, publicKeyBuff, this.prefix);
+      return signatures.ton.isValidSignature(signatureBuff, payload, publicKeyBuff, prefix);
     } else {
       return signatures.isValid(signature ?? "", payload, pk ?? "");
     }


### PR DESCRIPTION
## Summary
- validate signatures using the signing scheme and prefix recorded with each signature
- add regression test for verifying signatures after mutating DTO fields

## Testing
- `CI=1 npx nx test chain-api`


------
https://chatgpt.com/codex/tasks/task_e_68b89fe8b4748330b8282eacbc465a2b