### PR TITLE
feat: omit signatures field from payload hashing

### DIFF
--- a/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
@@ -12,6 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createHash } from "crypto";
+
 import { getPayloadToSign } from "./getPayloadToSign";
 
 describe("getPayloadToSign", () => {
@@ -26,14 +28,37 @@ describe("getPayloadToSign", () => {
     expect(toSign).toEqual('{"a":3,"b":[{"x":4,"y":5,"z":6},7],"c":8}');
   });
 
-  it("should ignore 'signature' and 'trace' fields", () => {
+  it("should ignore 'signature', 'signatures' and 'trace' fields", () => {
     // Given
-    const obj = { c: 8, signature: "to-be-ignored", trace: 3 };
+    const obj = {
+      c: 8,
+      signature: "to-be-ignored",
+      signatures: ["to-be-ignored"],
+      trace: 3
+    };
 
     // When
     const toSign = getPayloadToSign(obj);
 
     // Then
     expect(toSign).toEqual('{"c":8}');
+  });
+
+  it("should produce identical payload hashes whether signatures are present or not", () => {
+    // Given
+    const base = { c: 8 };
+    const withSignature = { ...base, signature: "to-be-ignored" };
+    const withSignatures = { ...base, signatures: ["to-be-ignored"] };
+
+    const hash = (s: string) => createHash("sha256").update(s).digest("hex");
+
+    // When
+    const baseHash = hash(getPayloadToSign(base));
+    const signatureHash = hash(getPayloadToSign(withSignature));
+    const signaturesHash = hash(getPayloadToSign(withSignatures));
+
+    // Then
+    expect(signatureHash).toEqual(baseHash);
+    expect(signaturesHash).toEqual(baseHash);
   });
 });

--- a/chain-api/src/utils/signatures/getPayloadToSign.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.ts
@@ -43,6 +43,6 @@ export function getPayloadToSign(obj: object): string {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { signature, trace, ...plain } = instanceToPlain(obj);
+  const { signature, signatures, trace, ...plain } = instanceToPlain(obj);
   return serialize(plain);
 }


### PR DESCRIPTION
## Summary
- ignore `signatures` when preparing payload to sign
- add tests ensuring payload hashes are unaffected by signature fields

## Testing
- `CI=1 npx nx test chain-api --output-style=stream`

------
https://chatgpt.com/codex/tasks/task_e_68b8a33fa0a08330ab1d09bb69c012c3