### PR TITLE
feat: add multisig helpers and signing support

### DIFF
--- a/chain-api/src/client/api/PublicKeyContractAPI.ts
+++ b/chain-api/src/client/api/PublicKeyContractAPI.ts
@@ -48,11 +48,21 @@ export const publicKeyContractAPI = (client: ChainClient): PublicKeyContractAPI 
   },
 
   RegisterUser(dto: RegisterUserDto) {
-    return client.submitTransaction("RegisterUser", dto) as Promise<GalaChainResponse<string>>;
+    const payload = Object.assign(new RegisterUserDto(), dto, {
+      requiredSignatures: dto.requiredSignatures ?? dto.publicKeys.length
+    });
+    return client.submitTransaction("RegisterUser", payload) as Promise<
+      GalaChainResponse<string>
+    >;
   },
 
   RegisterEthUser(dto: RegisterEthUserDto) {
-    return client.submitTransaction("RegisterEthUser", dto) as Promise<GalaChainResponse<string>>;
+    const payload = Object.assign(new RegisterEthUserDto(), dto, {
+      requiredSignatures: dto.requiredSignatures ?? dto.publicKeys.length
+    });
+    return client.submitTransaction("RegisterEthUser", payload) as Promise<
+      GalaChainResponse<string>
+    >;
   },
 
   UpdatePublicKey(dto: UpdatePublicKeyDto) {

--- a/chain-connect/src/chainApis/PublicKeyApi.ts
+++ b/chain-connect/src/chainApis/PublicKeyApi.ts
@@ -64,9 +64,14 @@ export class PublicKeyApi extends GalaChainBaseApi {
    * @returns Promise resolving to registration confirmation
    */
   public RegisterUser(dto: RegisterUserRequest) {
+    const payload: RegisterUserRequest = {
+      ...dto,
+      requiredSignatures:
+        dto.requiredSignatures ?? (dto.publicKeys as unknown as string[]).length
+    };
     return this.connection.submit<string, RegisterUserDto>({
       method: "RegisterUser",
-      payload: dto,
+      payload,
       sign: true,
       url: this.chainCodeUrl,
       requestConstructor: RegisterUserDto
@@ -79,9 +84,14 @@ export class PublicKeyApi extends GalaChainBaseApi {
    * @returns Promise resolving to registration confirmation
    */
   public RegisterEthUser(dto: RegisterEthUserRequest) {
+    const payload: RegisterEthUserRequest = {
+      ...dto,
+      requiredSignatures:
+        dto.requiredSignatures ?? (dto.publicKeys as unknown as string[]).length
+    };
     return this.connection.submit<string, RegisterEthUserDto>({
       method: "RegisterEthUser",
-      payload: dto,
+      payload,
       sign: true,
       url: this.chainCodeUrl,
       requestConstructor: RegisterEthUserDto

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -138,6 +138,8 @@ export class BrowserConnectClient extends WebSigner {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
+      delete (basePayload as any).signature;
+      delete (basePayload as any).signatures;
 
       const domain = { name: "GalaChain" };
       const types = generateEIP712Types(method, basePayload);

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -140,6 +140,9 @@ export class BrowserConnectClient extends WebSigner {
       delete basePayload.domain;
       delete (basePayload as any).signature;
       delete (basePayload as any).signatures;
+      delete (basePayload as any).signerAddress;
+      delete (basePayload as any).signerPublicKey;
+      delete (basePayload as any).prefix;
 
       const domain = { name: "GalaChain" };
       const types = generateEIP712Types(method, basePayload);

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -185,8 +185,9 @@ export class BrowserConnectClient extends WebSigner {
       };
 
       return {
-        ...prefixedPayload,
+        ...payload,
         ...additional,
+        prefix,
         signature,
         signatures: [...existing, signatureDto]
       } as T & { signature: string; prefix: string; signatures: SignatureDto[] };

--- a/chain-connect/src/customClients/PresignedClient.ts
+++ b/chain-connect/src/customClients/PresignedClient.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { SignatureDto } from "@gala-chain/api";
 import { GalaChainProvider, GalaChainProviderOptions } from "../GalaChainClient";
 
 /**
@@ -25,7 +26,10 @@ export class PresignedClient extends GalaChainProvider {
     super(options);
   }
 
-  public async sign<U extends object>(_method: string, payload: U & { signature: string; prefix?: string }) {
+  public async sign<U extends object>(
+    _method: string,
+    payload: U & { signature: string; prefix?: string; signatures?: SignatureDto[] }
+  ) {
     return payload;
   }
 }

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -53,6 +53,8 @@ export class SigningClient extends CustomClient {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
+      delete (basePayload as any).signature;
+      delete (basePayload as any).signatures;
 
       const prefix = calculatePersonalSignPrefix(basePayload);
       const prefixedPayload = { ...basePayload, prefix };

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -55,6 +55,9 @@ export class SigningClient extends CustomClient {
       delete basePayload.domain;
       delete (basePayload as any).signature;
       delete (basePayload as any).signatures;
+      delete (basePayload as any).signerAddress;
+      delete (basePayload as any).signerPublicKey;
+      delete (basePayload as any).prefix;
 
       const prefix = calculatePersonalSignPrefix(basePayload);
       const prefixedPayload = { ...basePayload, prefix };

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { serialize } from "@gala-chain/api";
+import { serialize, SignatureDto, SigningScheme } from "@gala-chain/api";
 import { SigningKey, computeAddress, ethers, hashMessage } from "ethers";
 
 import { CustomClient, GalaChainProviderOptions } from "../GalaChainClient";
@@ -48,23 +48,48 @@ export class SigningClient extends CustomClient {
     method: string,
     payload: U,
     signingType: SigningType = this.options?.signingType ?? SigningType.SIGN_TYPED_DATA
-  ): Promise<U & { signature: string; prefix?: string }> {
+  ): Promise<U & { signature: string; prefix?: string; signatures: SignatureDto[] }> {
     try {
-      const prefix = calculatePersonalSignPrefix(payload);
-      const prefixedPayload = { ...payload, prefix };
+      const basePayload = { ...payload } as Record<string, unknown>;
+      delete basePayload.types;
+      delete basePayload.domain;
+
+      const prefix = calculatePersonalSignPrefix(basePayload);
+      const prefixedPayload = { ...basePayload, prefix };
+
+      let signature: string;
+      const additional: Record<string, unknown> = {};
 
       if (signingType === SigningType.SIGN_TYPED_DATA) {
         const domain = { name: "GalaChain" };
-        const types = generateEIP712Types(method, payload);
-
-        const signature = await this.wallet.signTypedData(domain, types, prefixedPayload);
-        return { ...prefixedPayload, signature, types, domain };
+        const types = generateEIP712Types(method, basePayload);
+        signature = await this.wallet.signTypedData(domain, types, prefixedPayload);
+        additional.types = types;
+        additional.domain = domain;
       } else if (signingType === SigningType.PERSONAL_SIGN) {
-        const signature = await this.wallet.signMessage(serialize(prefixedPayload));
-        return { ...prefixedPayload, signature };
+        signature = await this.wallet.signMessage(serialize(prefixedPayload));
       } else {
         throw new Error("Unsupported signing type");
       }
+
+      const existing = Array.isArray((payload as any).signatures)
+        ? ((payload as any).signatures as SignatureDto[])
+        : [];
+
+      const signatureDto: SignatureDto = {
+        signature,
+        signerPublicKey: this.wallet.signingKey.publicKey,
+        signerAddress: this.ethereumAddress,
+        signing: SigningScheme.ETH,
+        prefix
+      };
+
+      return {
+        ...prefixedPayload,
+        ...additional,
+        signature,
+        signatures: [...existing, signatureDto]
+      } as U & { signature: string; prefix?: string; signatures: SignatureDto[] };
     } catch (error: unknown) {
       throw new Error((error as Error).message);
     }

--- a/chain-connect/src/helpers.spec.ts
+++ b/chain-connect/src/helpers.spec.ts
@@ -12,7 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { calculatePersonalSignPrefix } from "./helpers";
+import { calculatePersonalSignPrefix, composeMultisigDto, recoverPublicKeysFromDto } from "./helpers";
+import { SigningClient } from "./customClients/SigningClient";
+import { SigningType } from "./types";
 
 describe("calculatePersonalSignPrefix", () => {
   it("should return the correct prefix for a simple payload", () => {
@@ -75,5 +77,27 @@ describe("calculatePersonalSignPrefix", () => {
     const expectedPrefix = "\u0019Ethereum Signed Message:\n1062";
 
     expect(prefix).toBe(expectedPrefix);
+  });
+
+  it("should compose multisig dto and recover public keys", async () => {
+    const client1 = new SigningClient(
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
+    const client2 = new SigningClient(
+      "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+    );
+
+    const dto = { value: "test" };
+    const signed = await composeMultisigDto(
+      "TestMethod",
+      dto,
+      [client1, client2],
+      SigningType.PERSONAL_SIGN
+    );
+
+    expect(signed.signatures).toHaveLength(2);
+
+    const recovered = recoverPublicKeysFromDto(signed as any);
+    expect(recovered).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- support requiredSignatures and public key arrays in PublicKey APIs
- append multiple signatures in signing clients
- add utilities to compose multisig DTOs and recover signer keys

## Testing
- `./node_modules/.bin/nx test chain-connect --output-style=stream`
- `./node_modules/.bin/nx test chain-api --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_68b8d968c60883308796cad75f7ae4a9