### PR TITLE
fix: drop previous signatures before signing

### DIFF
--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -138,6 +138,8 @@ export class BrowserConnectClient extends WebSigner {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
+      delete (basePayload as any).signature;
+      delete (basePayload as any).signatures;
 
       const domain = { name: "GalaChain" };
       const types = generateEIP712Types(method, basePayload);

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -53,6 +53,8 @@ export class SigningClient extends CustomClient {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
+      delete (basePayload as any).signature;
+      delete (basePayload as any).signatures;
 
       const prefix = calculatePersonalSignPrefix(basePayload);
       const prefixedPayload = { ...basePayload, prefix };


### PR DESCRIPTION
## Summary
- remove existing `signature` and `signatures` from payload before computing hashes
- ensure all signers produce signatures over identical base payloads

## Testing
- `./node_modules/.bin/nx test chain-connect --output-style=stream`
- `./node_modules/.bin/nx test chain-api --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_68b8faafa82c83309c71b9c516545583