### PR TITLE
fix: remove prior signer metadata before hashing

### DIFF
--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -140,6 +140,9 @@ export class BrowserConnectClient extends WebSigner {
       delete basePayload.domain;
       delete (basePayload as any).signature;
       delete (basePayload as any).signatures;
+      delete (basePayload as any).signerAddress;
+      delete (basePayload as any).signerPublicKey;
+      delete (basePayload as any).prefix;
 
       const domain = { name: "GalaChain" };
       const types = generateEIP712Types(method, basePayload);

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -185,8 +185,9 @@ export class BrowserConnectClient extends WebSigner {
       };
 
       return {
-        ...prefixedPayload,
+        ...payload,
         ...additional,
+        prefix,
         signature,
         signatures: [...existing, signatureDto]
       } as T & { signature: string; prefix: string; signatures: SignatureDto[] };

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -55,6 +55,9 @@ export class SigningClient extends CustomClient {
       delete basePayload.domain;
       delete (basePayload as any).signature;
       delete (basePayload as any).signatures;
+      delete (basePayload as any).signerAddress;
+      delete (basePayload as any).signerPublicKey;
+      delete (basePayload as any).prefix;
 
       const prefix = calculatePersonalSignPrefix(basePayload);
       const prefixedPayload = { ...basePayload, prefix };


### PR DESCRIPTION
## Summary
- strip existing signature metadata before hashing and signing in browser and wallet clients

## Testing
- `./node_modules/.bin/nx test chain-connect --output-style=stream`
- `./node_modules/.bin/nx test chain-api --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_68b8fdadc9488330ba9e6852a5ce167f