### PR TITLE
fix: preserve signer metadata after signing

### DIFF
--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -185,8 +185,9 @@ export class BrowserConnectClient extends WebSigner {
       };
 
       return {
-        ...prefixedPayload,
+        ...payload,
         ...additional,
+        prefix,
         signature,
         signatures: [...existing, signatureDto]
       } as T & { signature: string; prefix: string; signatures: SignatureDto[] };


### PR DESCRIPTION
## Summary
- ensure BrowserConnectClient returns payload with original signer metadata

## Testing
- `./node_modules/.bin/nx test chain-connect --output-style=stream`
- `./node_modules/.bin/nx test chain-api --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_68b9000f1a808330aca0e2a122e3f74c