### PR TITLE
Add multisig tests and documentation

### DIFF
--- a/chain-cli/chaincode-template/e2e/multisig.spec.ts
+++ b/chain-cli/chaincode-template/e2e/multisig.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChainUser,
+  RegisterUserDto,
+  UpdatePublicKeyDto,
+  createValidSubmitDTO,
+  signatures
+} from "@gala-chain/api";
+import { AdminChainClients, TestClients, transactionErrorKey, transactionSuccess } from "@gala-chain/test";
+
+jest.setTimeout(30000);
+
+describe("multisig registration and quorum", () => {
+  let client: AdminChainClients;
+  let user: ChainUser;
+  const other = signatures.genKeyPair();
+
+  beforeAll(async () => {
+    client = await TestClients.createForAdmin();
+    user = ChainUser.withRandomKeys("e2e-multi");
+  });
+
+  afterAll(async () => {
+    await client.disconnect();
+  });
+
+  it("registers user with multiple keys", async () => {
+    const dto = await createValidSubmitDTO(RegisterUserDto, {
+      user: user.identityKey,
+      publicKeys: [user.publicKey, other.publicKey],
+      requiredSignatures: 2
+    });
+    const resp = await client.pk.RegisterUser(dto.signed(client.pk.privateKey));
+    expect(resp).toEqual(transactionSuccess());
+  });
+
+  it("prevents duplicate public keys", async () => {
+    const dup = ChainUser.withRandomKeys("dup-e2e");
+    const dto = await createValidSubmitDTO(RegisterUserDto, {
+      user: dup.identityKey,
+      publicKeys: [dup.publicKey, dup.publicKey],
+      requiredSignatures: 1
+    });
+    const resp = await client.pk.RegisterUser(dto.signed(client.pk.privateKey));
+    expect(resp).toEqual(transactionErrorKey("PK_DUPLICATE"));
+  });
+
+  it("enforces signature quorum on UpdatePublicKey", async () => {
+    const newKey = signatures.genKeyPair();
+
+    const insufficient = await createValidSubmitDTO(UpdatePublicKeyDto, {
+      publicKey: newKey.publicKey
+    });
+    const resp1 = await client.pk.UpdatePublicKey(insufficient.signed(user.privateKey));
+    expect(resp1).toEqual(transactionErrorKey("UNAUTHORIZED"));
+
+    const dup = await createValidSubmitDTO(UpdatePublicKeyDto, {
+      publicKey: newKey.publicKey
+    });
+    dup.sign(user.privateKey);
+    dup.signerPublicKey = user.publicKey;
+    dup.sign(user.privateKey);
+    const respDup = await client.pk.UpdatePublicKey(dup);
+    expect(respDup).toEqual(transactionErrorKey("DUPLICATE_SIGNER_PUBLIC_KEY"));
+
+    const ok = await createValidSubmitDTO(UpdatePublicKeyDto, {
+      publicKey: newKey.publicKey
+    });
+    ok.sign(user.privateKey);
+    ok.signerPublicKey = other.publicKey;
+    ok.sign(other.privateKey);
+    const resp2 = await client.pk.UpdatePublicKey(ok);
+    expect(resp2).toEqual(transactionSuccess());
+  });
+});

--- a/chain-test/src/unit/multisig.spec.ts
+++ b/chain-test/src/unit/multisig.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChainCallDTO,
+  ChainUser,
+  GetPublicKeyDto,
+  RegisterUserDto,
+  createValidDTO,
+  createValidSubmitDTO,
+  signatures
+} from "@gala-chain/api";
+import {
+  TestChaincode,
+  transactionErrorKey,
+  transactionSuccess
+} from "@gala-chain/test";
+import {
+  GalaChainContext,
+  GalaContract,
+  GalaTransaction,
+  SUBMIT
+} from "@gala-chain/chaincode";
+import { PublicKeyContract } from "@gala-chain/chaincode";
+
+describe("multisig quorum enforcement", () => {
+  it("handles quorum and duplicate signatures", async () => {
+    const ContractClass = class extends GalaContract {
+      constructor() {
+        super("TestContract", "1.0.0");
+      }
+      public async Action(ctx: GalaChainContext, dto: ChainCallDTO): Promise<void> {}
+    };
+    const target = ContractClass.prototype;
+    const propertyKey = "Action";
+    const descriptor = Object.getOwnPropertyDescriptor(target, propertyKey) as PropertyDescriptor;
+    GalaTransaction({
+      type: SUBMIT,
+      in: ChainCallDTO,
+      out: "object",
+      enforceUniqueKey: true,
+      verifySignature: true,
+      quorum: 2
+    })(target, propertyKey, descriptor);
+    Object.defineProperty(target, propertyKey, descriptor);
+
+    const chaincode = new TestChaincode([PublicKeyContract, ContractClass]);
+
+    const user = ChainUser.withRandomKeys("multisig-user");
+    const other = signatures.genKeyPair();
+
+    const regDto = await createValidSubmitDTO(RegisterUserDto, {
+      user: user.identityKey,
+      publicKeys: [user.publicKey, other.publicKey],
+      requiredSignatures: 2
+    });
+    const regResp = await chaincode.invoke(
+      "PublicKeyContract:RegisterUser",
+      regDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string)
+    );
+    expect(regResp).toEqual(transactionSuccess());
+
+    const getDto = await createValidDTO(GetPublicKeyDto, { user: user.identityKey });
+    getDto.sign(process.env.DEV_ADMIN_PRIVATE_KEY as string);
+    const pkResp = await chaincode.invoke("PublicKeyContract:GetPublicKey", getDto);
+    expect(pkResp).toEqual(
+      transactionSuccess(
+        expect.objectContaining({
+          publicKeys: expect.arrayContaining([
+            signatures.normalizePublicKey(user.publicKey).toString("base64"),
+            signatures.normalizePublicKey(other.publicKey).toString("base64")
+          ])
+        })
+      )
+    );
+
+    const dtoInsufficient = new ChainCallDTO();
+    dtoInsufficient.sign(user.privateKey);
+    const r1 = await chaincode.invoke("TestContract:Action", dtoInsufficient);
+    expect(r1).toEqual(transactionErrorKey("UNAUTHORIZED"));
+
+    const dtoDup = new ChainCallDTO();
+    dtoDup.sign(user.privateKey);
+    dtoDup.sign(user.privateKey);
+    const r2 = await chaincode.invoke("TestContract:Action", dtoDup);
+    expect(r2).toEqual(transactionErrorKey("DUPLICATE_SIGNER_PUBLIC_KEY"));
+
+    const dtoOk = new ChainCallDTO();
+    dtoOk.sign(user.privateKey);
+    dtoOk.signerPublicKey = other.publicKey;
+    dtoOk.sign(other.privateKey);
+    const r3 = await chaincode.invoke("TestContract:Action", dtoOk);
+    expect(r3).toEqual(transactionSuccess());
+  });
+});

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChainCallDTO, ChainUser, UserProfile, UserRole } from "@gala-chain/api";
+import { ChainCallDTO, ChainUser, UserProfile, UserRole, signatures } from "@gala-chain/api";
 import {
   fixture,
   transactionErrorKey,
@@ -335,5 +335,118 @@ describe("authorization", () => {
 
     const resp = await f.contract.Action(f.ctx, dto);
     expect(resp).toEqual(transactionErrorKey("UNAUTHORIZED"));
+  });
+
+  it("should succeed when quorum is satisfied", async () => {
+    const ContractClass = class extends GalaContract {
+      constructor() {
+        super("TestContract", "1.0.0");
+      }
+
+      public async Action(ctx: GalaChainContext, dto: ChainCallDTO): Promise<void> {}
+    };
+
+    const target = ContractClass.prototype;
+    const propertyKey = "Action";
+    const descriptor = Object.getOwnPropertyDescriptor(target, propertyKey) as PropertyDescriptor;
+
+    GalaTransaction({
+      type: SUBMIT,
+      in: ChainCallDTO,
+      out: "object",
+      enforceUniqueKey: true,
+      verifySignature: true,
+      quorum: 2
+    })(target, propertyKey, descriptor);
+    Object.defineProperty(target, propertyKey, descriptor);
+
+    const user = { ...ChainUser.withRandomKeys("multi"), roles: [UserRole.SUBMIT] };
+    const other = signatures.genKeyPair();
+    const normalized1 = signatures.normalizePublicKey(user.publicKey).toString("base64");
+    const normalized2 = signatures.normalizePublicKey(other.publicKey).toString("base64");
+
+    const f = fixture(ContractClass)
+      .caClientIdentity(anonymousUserId, defaultMsp)
+      .savedKVState(
+        {
+          key: `\u0000GCPK\u0000${user.identityKey}\u0000`,
+          value: JSON.stringify({ publicKey: normalized1, publicKeys: [normalized1, normalized2] })
+        },
+        {
+          key: `\u0000GCUP\u0000${user.ethAddress}\u0000`,
+          value: JSON.stringify({
+            alias: user.identityKey,
+            ethAddress: user.ethAddress,
+            roles: [UserRole.EVALUATE, UserRole.SUBMIT],
+            pubKeyCount: 2,
+            requiredSignatures: 2
+          })
+        }
+      );
+
+    const dto = new ChainCallDTO();
+    dto.uniqueKey = "uniqueKey-quorum-success";
+    dto.sign(user.privateKey);
+    dto.signerPublicKey = other.publicKey;
+    dto.sign(other.privateKey);
+
+    const resp = await f.contract.Action(f.ctx, dto);
+    expect(resp).toEqual(transactionSuccess());
+  });
+
+  it("should fail with duplicate signer keys", async () => {
+    const ContractClass = class extends GalaContract {
+      constructor() {
+        super("TestContract", "1.0.0");
+      }
+
+      public async Action(ctx: GalaChainContext, dto: ChainCallDTO): Promise<void> {}
+    };
+
+    const target = ContractClass.prototype;
+    const propertyKey = "Action";
+    const descriptor = Object.getOwnPropertyDescriptor(target, propertyKey) as PropertyDescriptor;
+
+    GalaTransaction({
+      type: SUBMIT,
+      in: ChainCallDTO,
+      out: "object",
+      enforceUniqueKey: true,
+      verifySignature: true,
+      quorum: 2
+    })(target, propertyKey, descriptor);
+    Object.defineProperty(target, propertyKey, descriptor);
+
+    const user = { ...ChainUser.withRandomKeys("dup"), roles: [UserRole.SUBMIT] };
+    const other = signatures.genKeyPair();
+    const normalized1 = signatures.normalizePublicKey(user.publicKey).toString("base64");
+    const normalized2 = signatures.normalizePublicKey(other.publicKey).toString("base64");
+
+    const f = fixture(ContractClass)
+      .caClientIdentity(anonymousUserId, defaultMsp)
+      .savedKVState(
+        {
+          key: `\u0000GCPK\u0000${user.identityKey}\u0000`,
+          value: JSON.stringify({ publicKey: normalized1, publicKeys: [normalized1, normalized2] })
+        },
+        {
+          key: `\u0000GCUP\u0000${user.ethAddress}\u0000`,
+          value: JSON.stringify({
+            alias: user.identityKey,
+            ethAddress: user.ethAddress,
+            roles: [UserRole.EVALUATE, UserRole.SUBMIT],
+            pubKeyCount: 2,
+            requiredSignatures: 2
+          })
+        }
+      );
+
+    const dto = new ChainCallDTO();
+    dto.uniqueKey = "uniqueKey-quorum-dup";
+    dto.sign(user.privateKey);
+    dto.sign(user.privateKey);
+
+    const resp = await f.contract.Action(f.ctx, dto);
+    expect(resp).toEqual(transactionErrorKey("DUPLICATE_SIGNER_PUBLIC_KEY"));
   });
 });

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -193,6 +193,39 @@ The serialized payload string must be prepared in the same way as for Ethereum s
 signature = Ed25519Sign(privkey, sha256(0xffff ++ utf8_encode(seed) ++ sha256(message)))
 ```
 
+### Multisignature users and quorum enforcement
+
+GalaChain allows a single user to control multiple public keys. When registering a
+user, provide an array of `publicKeys` and specify how many unique signatures are
+required to authorize a transaction via the `requiredSignatures` field. The
+registered profile stores both the total key count and the signature threshold.
+
+Transactions include a `signatures` array. Each entry contains the detached
+`signature`, the `signerPublicKey` or `signerAddress`, and optional `signing`
+scheme information:
+
+```json
+[
+  { "signature": "0x..", "signerPublicKey": "pk1" },
+  { "signature": "0x..", "signerPublicKey": "pk2" }
+]
+```
+
+All signatures must come from different keys. During authorization the chaincode
+requires at least `max(user.requiredSignatures, quorum)` unique signatures. If too
+few signatures are provided or the same key is used twice, the transaction is
+rejected.
+
+#### Example
+
+```typescript
+const dto = await createValidSubmitDTO(UpdatePublicKeyDto, { publicKey: newKey });
+dto.sign(firstPrivateKey);
+dto.signerPublicKey = secondPublicKey;
+dto.sign(secondPrivateKey);
+await client.pk.UpdatePublicKey(dto); // succeeds with two signatures
+```
+
 ### Authenticating in the chaincode
 
 In the chaincode, before the transaction is executed, GalaChain SDK will recover the public key from the signature and check if the user is registered.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,6 +166,17 @@ Now you can run integration tests with:
 npm run test:e2e
 ```
 
+#### Register a multisig user
+
+Users may be registered with several public keys and a signature threshold:
+
+```bash
+galachain pk:register-user ./admin.key '{"user":"client|alice","publicKeys":["<pk1>","<pk2>"],"requiredSignatures":2}'
+```
+
+All submit transactions for this user must include signatures from at least two
+different keys.
+
 ### 5. Verify changes in block browser and GraphQL
 
 Navigate to [http://localhost:3010/blocks](http://localhost:3010/blocks) to see our block browser which allows you to see what's saved on your local GalaChain network.


### PR DESCRIPTION
## Summary
- extend authorization tests to cover quorum success and duplicate signers
- add multisig quorum test utilities and CLI template e2e coverage
- document multisignature users, signature arrays and quorum rules

## Testing
- `npx nx test chaincode` *(fails: Jest: Failed to parse the TypeScript config file)*
- `npx jest chain-test/src/unit/multisig.spec.ts --runInBand --config chain-test/jest.config.ts` *(fails: no output, process terminated)*
- `npm run test:e2e multisig.spec.ts` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b90394d21c833082bf6604eb3064a8