### PR TITLE
test: add connection profiles and guard multisig teardown

### DIFF
--- a/chain-cli/network/connection-profiles/cpp-curator.json
+++ b/chain-cli/network/connection-profiles/cpp-curator.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-network-CuratorOrg",
+  "version": "1.0.0",
+  "client": { "organization": "CuratorOrg" },
+  "organizations": {
+    "CuratorOrg": {
+      "mspid": "CuratorOrg",
+      "peers": ["peer0.curator.local"],
+      "certificateAuthorities": ["ca.curator.local"]
+    }
+  },
+  "peers": {
+    "peer0.curator.local": { "url": "grpc://peer0.curator.local:7041" }
+  },
+  "orderers": {
+    "orderer0.group1.orderer.local": { "url": "grpc://orderer0.group1.orderer.local:7030" }
+  },
+  "certificateAuthorities": {
+    "ca.curator.local": {
+      "url": "http://ca.curator.local:7040",
+      "caName": "ca.curator.local"
+    }
+  }
+}

--- a/chain-cli/network/connection-profiles/cpp-partner.json
+++ b/chain-cli/network/connection-profiles/cpp-partner.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-network-PartnerOrg1",
+  "version": "1.0.0",
+  "client": { "organization": "PartnerOrg1" },
+  "organizations": {
+    "PartnerOrg1": {
+      "mspid": "PartnerOrg1",
+      "peers": ["peer0.partner1.local"],
+      "certificateAuthorities": ["ca.partner1.local"]
+    }
+  },
+  "peers": {
+    "peer0.partner1.local": { "url": "grpc://peer0.partner1.local:7061" }
+  },
+  "orderers": {
+    "orderer0.group1.orderer.local": { "url": "grpc://orderer0.group1.orderer.local:7030" }
+  },
+  "certificateAuthorities": {
+    "ca.partner1.local": {
+      "url": "http://ca.partner1.local:7060",
+      "caName": "ca.partner1.local"
+    }
+  }
+}

--- a/chain-cli/network/connection-profiles/cpp-users.json
+++ b/chain-cli/network/connection-profiles/cpp-users.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-network-UsersOrg1",
+  "version": "1.0.0",
+  "client": { "organization": "UsersOrg1" },
+  "organizations": {
+    "CuratorOrg": { "mspid": "CuratorOrg", "peers": ["peer0.curator.local"] },
+    "PartnerOrg1": { "mspid": "PartnerOrg1", "peers": ["peer0.partner1.local"] },
+    "UsersOrg1": { "mspid": "UsersOrg1", "certificateAuthorities": ["ca.users1.local"] }
+  },
+  "peers": {
+    "peer0.curator.local": { "url": "grpc://peer0.curator.local:7041" },
+    "peer0.partner1.local": { "url": "grpc://peer0.partner1.local:7061" }
+  },
+  "orderers": {
+    "orderer0.group1.orderer.local": { "url": "grpc://orderer0.group1.orderer.local:7030" }
+  },
+  "certificateAuthorities": {
+    "ca.users1.local": {
+      "url": "http://ca.users1.local:7080",
+      "caName": "ca.users1.local"
+    }
+  }
+}

--- a/chain-test/src/e2e/multisig.spec.ts
+++ b/chain-test/src/e2e/multisig.spec.ts
@@ -50,7 +50,9 @@ describe("multisig e2e", () => {
   });
 
   afterAll(async () => {
-    await client.disconnect();
+    if (client) {
+      await client.disconnect();
+    }
   });
 
   it("rejects calls with insufficient signatures", async () => {


### PR DESCRIPTION
## Summary
- add minimal Fabric connection profiles for Curator, Partner, and Users orgs
- guard multisig spec teardown so disconnect is only called when client exists

## Testing
- `CURATORORG_MOCKED_CHAINCODE_DIR=mock-chaincode USERSORG1_MOCKED_CHAINCODE_DIR=mock-chaincode PARTNERORG1_MOCKED_CHAINCODE_DIR=mock-chaincode npx nx run chain-test:test --output-style=static` *(fails: Test Suites: 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b19071ec8330831292a51044e715