### PR TITLE
test: avoid ts-jest transforming JS

### DIFF
--- a/chain-cli/chaincode-template/jest.config.ts
+++ b/chain-cli/chaincode-template/jest.config.ts
@@ -20,7 +20,7 @@ export default {
   displayName: "chaincode-template",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js"],
   modulePathIgnorePatterns: ["lib", "e2e"]

--- a/chain-cli/jest.config.ts
+++ b/chain-cli/jest.config.ts
@@ -19,7 +19,7 @@ export default {
   preset: "../jest.preset.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../coverage/chain-cli",

--- a/chain-client/jest.config.ts
+++ b/chain-client/jest.config.ts
@@ -19,7 +19,7 @@ export default {
   preset: "../jest.preset.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../coverage/chain-client"

--- a/chain-test/jest.config.ts
+++ b/chain-test/jest.config.ts
@@ -26,7 +26,7 @@ export default {
   preset: "../jest.preset.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../coverage/chain-test"

--- a/chaincode/jest.config.ts
+++ b/chaincode/jest.config.ts
@@ -19,7 +19,7 @@ export default {
   preset: "../jest.preset.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+    "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../coverage/chaincode",


### PR DESCRIPTION
## Summary
- limit ts-jest transform to `.ts` files in Jest configs

## Testing
- `npx nx test chain-api --output-style=stream`
- `npx nx run-many -t test --projects chain-api,chain-cli,chain-client,chain-connect,chain-test,chaincode --output-style=stream` *(fails: chaincode tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9de5b74fc8330b55d6492fe1f92b3