### PR TITLE
fix: allow JS files in test builds

### DIFF
--- a/chain-test/tsconfig.spec.json
+++ b/chain-test/tsconfig.spec.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "types": ["jest", "node"],
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "allowJs": true
   },
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"],
   "references": [

--- a/chaincode/tsconfig.spec.json
+++ b/chaincode/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "sourceMap": true
+    "sourceMap": true,
+    "allowJs": true
   },
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- allow jest to compile .js files in chain-test
- allow jest to compile .js files in chaincode

## Testing
- `npx jest --config chain-test/jest.config.ts chain-test/src/e2e/TestClients.spec.ts`
- `npx jest --config chaincode/jest.config.ts chaincode/src/contracts/GalaContract.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9e7b71d448330b7b0f5b7953dd31c