### PR TITLE
Remove requiredSignatures parameter and default to majority

### DIFF
--- a/chain-api/src/client/api/PublicKeyContractAPI.ts
+++ b/chain-api/src/client/api/PublicKeyContractAPI.ts
@@ -48,16 +48,12 @@ export const publicKeyContractAPI = (client: ChainClient): PublicKeyContractAPI 
   },
 
   RegisterUser(dto: RegisterUserDto) {
-    const payload = Object.assign(new RegisterUserDto(), dto, {
-      requiredSignatures: dto.requiredSignatures ?? dto.publicKeys.length
-    });
+    const payload = Object.assign(new RegisterUserDto(), dto);
     return client.submitTransaction("RegisterUser", payload) as Promise<GalaChainResponse<string>>;
   },
 
   RegisterEthUser(dto: RegisterEthUserDto) {
-    const payload = Object.assign(new RegisterEthUserDto(), dto, {
-      requiredSignatures: dto.requiredSignatures ?? dto.publicKeys.length
-    });
+    const payload = Object.assign(new RegisterEthUserDto(), dto);
     return client.submitTransaction("RegisterEthUser", payload) as Promise<GalaChainResponse<string>>;
   },
 

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -654,12 +654,6 @@ export class RegisterUserDto extends SubmitCallDTO {
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
   publicKeys: string[];
-
-  @JSONSchema({ description: "Number of required signatures." })
-  @IsNumber()
-  @Min(1)
-  @MaxArrayLength("publicKeys")
-  requiredSignatures: number;
 }
 
 /**
@@ -676,12 +670,6 @@ export class RegisterEthUserDto extends SubmitCallDTO {
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
   publicKeys: string[];
-
-  @JSONSchema({ description: "Number of required signatures." })
-  @IsNumber()
-  @Min(1)
-  @MaxArrayLength("publicKeys")
-  requiredSignatures: number;
 }
 
 /**
@@ -698,12 +686,6 @@ export class RegisterTonUserDto extends SubmitCallDTO {
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
   publicKeys: string[];
-
-  @JSONSchema({ description: "Number of required signatures." })
-  @IsNumber()
-  @Min(1)
-  @MaxArrayLength("publicKeys")
-  requiredSignatures: number;
 }
 
 export class UpdatePublicKeyDto extends SubmitCallDTO {

--- a/chain-connect/src/ClientApi.spec.ts
+++ b/chain-connect/src/ClientApi.spec.ts
@@ -109,7 +109,6 @@ describe("API tests", () => {
   it("test register", async () => {
     const dto: RegisterUserDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: ["3"],
-      requiredSignatures: 1,
       user: "client|4" as UserAlias
     });
 
@@ -137,7 +136,6 @@ describe("API tests", () => {
   it("test both using same connection", async () => {
     const dto: RegisterUserDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: ["3"],
-      requiredSignatures: 1,
       user: "client|4" as UserAlias
     });
 

--- a/chain-connect/src/chainApis/PublicKeyApi.ts
+++ b/chain-connect/src/chainApis/PublicKeyApi.ts
@@ -64,10 +64,7 @@ export class PublicKeyApi extends GalaChainBaseApi {
    * @returns Promise resolving to registration confirmation
    */
   public RegisterUser(dto: RegisterUserRequest) {
-    const payload: RegisterUserRequest = {
-      ...dto,
-      requiredSignatures: dto.requiredSignatures ?? (dto.publicKeys as unknown as string[]).length
-    };
+    const payload: RegisterUserRequest = { ...dto };
     return this.connection.submit<string, RegisterUserDto>({
       method: "RegisterUser",
       payload,
@@ -83,10 +80,7 @@ export class PublicKeyApi extends GalaChainBaseApi {
    * @returns Promise resolving to registration confirmation
    */
   public RegisterEthUser(dto: RegisterEthUserRequest) {
-    const payload: RegisterEthUserRequest = {
-      ...dto,
-      requiredSignatures: dto.requiredSignatures ?? (dto.publicKeys as unknown as string[]).length
-    };
+    const payload: RegisterEthUserRequest = { ...dto };
     return this.connection.submit<string, RegisterEthUserDto>({
       method: "RegisterEthUser",
       payload,

--- a/chain-test/src/e2e/TestClients.ts
+++ b/chain-test/src/e2e/TestClients.ts
@@ -372,8 +372,7 @@ async function createRegisteredUser(
 
   if (userAlias === undefined) {
     const dto = await createValidSubmitDTO(RegisterEthUserDto, {
-      publicKeys: [user.publicKey],
-      requiredSignatures: 1
+      publicKeys: [user.publicKey]
     });
     const response = await client.RegisterEthUser(dto.signed(client.privateKey));
     if (response.Status !== GalaChainResponseType.Success) {
@@ -382,8 +381,7 @@ async function createRegisteredUser(
   } else {
     const dto = await createValidSubmitDTO(RegisterUserDto, {
       user: user.identityKey,
-      publicKeys: [user.publicKey],
-      requiredSignatures: 1
+      publicKeys: [user.publicKey]
     });
     const response = await client.RegisterUser(dto.signed(client.privateKey));
     if (response.Status !== GalaChainResponseType.Success) {

--- a/chain-test/src/e2e/multisig.spec.ts
+++ b/chain-test/src/e2e/multisig.spec.ts
@@ -42,8 +42,7 @@ describe("multisig e2e", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey],
-      requiredSignatures: 2
+      publicKeys: [kp1.publicKey, kp2.publicKey]
     });
     const regResp = await client.pk.RegisterUser(regDto.signed(client.pk.privateKey));
     expect(regResp).toEqual(transactionSuccess());

--- a/chaincode/src/__test__/MockedChaincodeClient.spec.ts
+++ b/chaincode/src/__test__/MockedChaincodeClient.spec.ts
@@ -77,8 +77,7 @@ it("should support the global state", async () => {
   const client2 = createClient(chaincodeDir);
 
   const registerDto = await createValidSubmitDTO(RegisterEthUserDto, {
-    publicKeys: [user.publicKey],
-    requiredSignatures: 1
+    publicKeys: [user.publicKey]
   });
   registerDto.sign(admin.privateKey);
 
@@ -115,8 +114,7 @@ it("should not change the state for evaluateTransaction", async () => {
   const otherUserAlias = `eth|${signatures.getEthAddress(otherUser.publicKey)}` as UserAlias;
 
   const registerDto = await createValidSubmitDTO(RegisterEthUserDto, {
-    publicKeys: [otherUser.publicKey],
-    requiredSignatures: 1
+    publicKeys: [otherUser.publicKey]
   });
   registerDto.sign(admin.privateKey);
 
@@ -146,8 +144,7 @@ it.skip("should support key collision validation", async () => {
 
   const otherUser = signatures.genKeyPair();
   const registerDto = await createValidSubmitDTO(RegisterEthUserDto, {
-    publicKeys: [otherUser.publicKey],
-    requiredSignatures: 1
+    publicKeys: [otherUser.publicKey]
   });
   registerDto.sign(admin.privateKey);
 

--- a/chaincode/src/contracts/PublicKeyContract.migration.spec.ts
+++ b/chaincode/src/contracts/PublicKeyContract.migration.spec.ts
@@ -70,8 +70,7 @@ describe("Migration from allowedOrgs to allowedRoles", () => {
 
   test("When: User is registered with no allowed role", async () => {
     const dto = await createValidSubmitDTO(RegisterEthUserDto, {
-      publicKeys: [user.publicKey],
-      requiredSignatures: 1
+      publicKeys: [user.publicKey]
     }).signed(adminPrivateKey);
     expect(await chaincode.invoke("PublicKeyContract:RegisterEthUser", dto)).toEqual(transactionSuccess());
 

--- a/chaincode/src/contracts/PublicKeyContract.spec.ts
+++ b/chaincode/src/contracts/PublicKeyContract.spec.ts
@@ -79,8 +79,7 @@ describe("RegisterUser", () => {
     const chaincode = new TestChaincode([PublicKeyContract]);
     const dto = await createValidSubmitDTO(RegisterUserDto, {
       user: "client|user1" as UserAlias,
-      publicKeys: [publicKey, otherPublicKey],
-      requiredSignatures: 2
+      publicKeys: [publicKey, otherPublicKey]
     });
     const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
 
@@ -120,7 +119,6 @@ describe("RegisterUser", () => {
 
     const registerDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: [user.publicKey],
-      requiredSignatures: 1,
       user: user.alias
     });
     const signedRegisterDto = registerDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
@@ -139,7 +137,6 @@ describe("RegisterUser", () => {
 
     const registerDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: [user.publicKey],
-      requiredSignatures: 1,
       user: "client|new_user" as UserAlias
     });
     const signedRegisterDto = registerDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
@@ -151,33 +148,13 @@ describe("RegisterUser", () => {
     expect(registerResponse).toEqual(expect.objectContaining({ Status: 0, ErrorKey: "PROFILE_EXISTS" }));
   });
 
-  it("should fail when required signatures exceed number of public keys", async () => {
-    // Given
-    const chaincode = new TestChaincode([PublicKeyContract]);
-    const { publicKey } = signatures.genKeyPair();
-    const other = signatures.genKeyPair().publicKey;
-    const dto = await createValidSubmitDTO(RegisterUserDto, {
-      user: "client|bad" as UserAlias,
-      publicKeys: [publicKey, other],
-      requiredSignatures: 3
-    });
-    const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
-
-    // When
-    const response = await chaincode.invoke("PublicKeyContract:RegisterUser", signedDto);
-
-    // Then
-    expect(response).toEqual(transactionErrorKey("PK_COUNT_MISMATCH"));
-  });
-
   it("should fail when duplicate public keys provided", async () => {
     // Given
     const chaincode = new TestChaincode([PublicKeyContract]);
     const { publicKey } = signatures.genKeyPair();
     const dto = await createValidSubmitDTO(RegisterUserDto, {
       user: "client|dup" as UserAlias,
-      publicKeys: [publicKey, publicKey],
-      requiredSignatures: 1
+      publicKeys: [publicKey, publicKey]
     });
     const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
 
@@ -197,7 +174,6 @@ describe("RegisterUser", () => {
     const dto = await createValidSubmitDTO<RegisterUserDto>(RegisterUserDto, {
       user: user2.alias,
       publicKeys: [user2.publicKey],
-      requiredSignatures: 1
     });
 
     const response = await chaincode.invoke("PublicKeyContract:SavePublicKey", dto);
@@ -211,7 +187,6 @@ describe("RegisterUser", () => {
     chaincode.setCallingUser("client|admin");
     const registerDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: [newPublicKey],
-      requiredSignatures: 1,
       user: user2.alias
     });
     const signedRegisterDto = registerDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
@@ -243,7 +218,6 @@ describe("RegisterUser", () => {
     const dto = await createValidSubmitDTO<RegisterUserDto>(RegisterUserDto, {
       user: user2.alias,
       publicKeys: [user2.publicKey],
-      requiredSignatures: 1
     });
 
     const response = await chaincode.invoke(
@@ -255,7 +229,6 @@ describe("RegisterUser", () => {
     chaincode.setCallingUser("client|admin");
     const registerDto = await createValidSubmitDTO(RegisterUserDto, {
       publicKeys: [user2.publicKey],
-      requiredSignatures: 1,
       user: user2.alias
     });
     const signedRegisterDto = registerDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
@@ -287,8 +260,7 @@ describe("RegisterUser", () => {
 
     const chaincode = new TestChaincode([PublicKeyContract]);
     const dto = await createValidSubmitDTO<RegisterEthUserDto>(RegisterEthUserDto, {
-      publicKeys: [publicKey],
-      requiredSignatures: 1
+      publicKeys: [publicKey]
     });
     const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
 
@@ -323,8 +295,7 @@ describe("RegisterUser", () => {
 
     const chaincode = new TestChaincode([PublicKeyContract]);
     const dto = await createValidSubmitDTO<RegisterTonUserDto>(RegisterTonUserDto, {
-      publicKeys: [publicKey],
-      requiredSignatures: 1
+      publicKeys: [publicKey]
     });
     const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
 
@@ -391,8 +362,7 @@ describe("UpdatePublicKey", () => {
     const other = signatures.genKeyPair();
     const registerDto = await createValidSubmitDTO(RegisterUserDto, {
       user: user.alias,
-      publicKeys: [user.publicKey, other.publicKey],
-      requiredSignatures: 2
+      publicKeys: [user.publicKey, other.publicKey]
     });
     const signedRegisterDto = registerDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
     expect(await chaincode.invoke("PublicKeyContract:RegisterUser", signedRegisterDto)).toEqual(
@@ -471,8 +441,7 @@ describe("UpdatePublicKey", () => {
     // Given
     const dto = await createValidSubmitDTO<RegisterUserDto>(RegisterUserDto, {
       user: "client|newUser" as UserAlias,
-      publicKeys: [oldPublicKey],
-      requiredSignatures: 1
+      publicKeys: [oldPublicKey]
     });
     const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
 

--- a/chaincode/src/contracts/PublicKeyContract.ts
+++ b/chaincode/src/contracts/PublicKeyContract.ts
@@ -31,7 +31,7 @@ import {
 import { Info } from "fabric-contract-api";
 
 import { PublicKeyService } from "../services";
-import { PkCountMismatchError, PkNotFoundError } from "../services/PublicKeyError";
+import { PkNotFoundError } from "../services/PublicKeyError";
 import { GalaChainContext } from "../types";
 import { GalaContract } from "./GalaContract";
 import { EVALUATE, Evaluate, GalaTransaction, Submit } from "./GalaTransaction";
@@ -65,16 +65,6 @@ export class PublicKeyContract extends GalaContract {
     }
   }
 
-  private static validateRequiredSignatures(
-    publicKeys: string[],
-    required: number,
-    userAlias: UserAlias
-  ): void {
-    if (required < 1 || required > publicKeys.length) {
-      throw new PkCountMismatchError(userAlias, publicKeys.length, required);
-    }
-  }
-
   @Evaluate({
     in: GetMyProfileDto,
     description:
@@ -101,15 +91,13 @@ export class PublicKeyContract extends GalaContract {
     const providedPkHex = signatures.getNonCompactHexPublicKey(dto.publicKeys[0]);
     const ethAddress = signatures.getEthAddress(providedPkHex);
     const userAlias = dto.user;
-    PublicKeyContract.validateRequiredSignatures(dto.publicKeys, dto.requiredSignatures, userAlias);
 
     return PublicKeyService.registerUser(
       ctx,
       dto.publicKeys,
       ethAddress,
       userAlias,
-      SigningScheme.ETH,
-      dto.requiredSignatures
+      SigningScheme.ETH
     );
   }
 
@@ -124,15 +112,13 @@ export class PublicKeyContract extends GalaContract {
     const providedPkHex = signatures.getNonCompactHexPublicKey(dto.publicKeys[0]);
     const ethAddress = signatures.getEthAddress(providedPkHex);
     const userAlias = `eth|${ethAddress}` as UserAlias;
-    PublicKeyContract.validateRequiredSignatures(dto.publicKeys, dto.requiredSignatures, userAlias);
 
     return PublicKeyService.registerUser(
       ctx,
       dto.publicKeys,
       ethAddress,
       userAlias,
-      SigningScheme.ETH,
-      dto.requiredSignatures
+      SigningScheme.ETH
     );
   }
 
@@ -147,15 +133,13 @@ export class PublicKeyContract extends GalaContract {
     const publicKey = dto.publicKeys[0];
     const address = signatures.ton.getTonAddress(Buffer.from(publicKey, "base64"));
     const userAlias = `ton|${address}` as UserAlias;
-    PublicKeyContract.validateRequiredSignatures(dto.publicKeys, dto.requiredSignatures, userAlias);
 
     return PublicKeyService.registerUser(
       ctx,
       dto.publicKeys,
       address,
       userAlias,
-      SigningScheme.TON,
-      dto.requiredSignatures
+      SigningScheme.TON
     );
   }
 

--- a/chaincode/src/contracts/authenticate.multisig.spec.ts
+++ b/chaincode/src/contracts/authenticate.multisig.spec.ts
@@ -34,8 +34,7 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey],
-      requiredSignatures: 2
+      publicKeys: [kp1.publicKey, kp2.publicKey]
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -62,8 +61,7 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey],
-      requiredSignatures: 2
+      publicKeys: [kp1.publicKey, kp2.publicKey]
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -86,8 +84,7 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: user.alias,
-      publicKeys: [user.publicKey, other.publicKey],
-      requiredSignatures: 2
+      publicKeys: [user.publicKey, other.publicKey]
     });
     const regSigned = regDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
     const regResp = await chaincode.invoke("PublicKeyContract:RegisterUser", regSigned);

--- a/chaincode/src/contracts/authenticate.testutils.spec.ts
+++ b/chaincode/src/contracts/authenticate.testutils.spec.ts
@@ -58,8 +58,7 @@ export async function createRegisteredUser(chaincode: TestChaincode): Promise<Us
   const { alias, privateKey, publicKey, ethAddress } = await createUser();
   const dto = await createValidSubmitDTO(RegisterUserDto, {
     user: alias,
-    publicKeys: [publicKey],
-    requiredSignatures: 1
+    publicKeys: [publicKey]
   });
   const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
   const response = await chaincode.invoke("PublicKeyContract:RegisterUser", signedDto);
@@ -79,8 +78,7 @@ export async function createTonUser(): Promise<TonUser> {
 export async function createRegisteredTonUser(chaincode: TestChaincode): Promise<TonUser> {
   const user = await createTonUser();
   const dto = await createValidSubmitDTO(RegisterTonUserDto, {
-    publicKeys: [user.publicKey],
-    requiredSignatures: 1
+    publicKeys: [user.publicKey]
   });
   const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
   const response = await chaincode.invoke("PublicKeyContract:RegisterTonUser", signedDto);

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -369,8 +369,7 @@ describe("authorization", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey],
-      requiredSignatures: 2
+      publicKeys: [kp1.publicKey, kp2.publicKey]
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -32,7 +32,6 @@ import { Context } from "fabric-contract-api";
 
 import { GalaChainContext } from "../types";
 import {
-  PkCountMismatchError,
   PkDuplicateError,
   PkInvalidSignatureError,
   PkMismatchError,
@@ -83,8 +82,7 @@ export class PublicKeyService {
     address: string,
     userAlias: UserAlias,
     signing: SigningScheme,
-    pubKeyCount: number,
-    requiredSignatures: number
+    pubKeyCount: number
   ): Promise<void> {
     const key = PublicKeyService.getUserProfileKey(ctx, address);
     const obj = new UserProfile();
@@ -97,7 +95,7 @@ export class PublicKeyService {
     }
     obj.roles = Array.from(UserProfile.DEFAULT_ROLES);
     obj.pubKeyCount = pubKeyCount;
-    obj.requiredSignatures = requiredSignatures;
+    obj.requiredSignatures = Math.floor(pubKeyCount / 2) + 1;
 
     const data = Buffer.from(obj.serialize());
     await ctx.stub.putState(key, data);
@@ -251,12 +249,8 @@ export class PublicKeyService {
     publicKeys: string[],
     ethAddress: string,
     userAlias: UserAlias,
-    signing: SigningScheme,
-    requiredSignatures: number
+    signing: SigningScheme
   ): Promise<string> {
-    if (requiredSignatures < 1 || requiredSignatures > publicKeys.length) {
-      throw new PkCountMismatchError(userAlias, publicKeys.length, requiredSignatures);
-    }
     const currPublicKey = await PublicKeyService.getPublicKey(ctx, userAlias);
     const firstPk = publicKeys[0];
     const providedPk =
@@ -288,8 +282,7 @@ export class PublicKeyService {
       ethAddress,
       userAlias,
       signing,
-      publicKeys.length,
-      requiredSignatures
+      publicKeys.length
     );
 
     return userAlias;
@@ -334,8 +327,7 @@ export class PublicKeyService {
       newAddress,
       userAlias,
       signing,
-      userProfile?.pubKeyCount ?? updatedKeys.length,
-      userProfile?.requiredSignatures ?? 1
+      userProfile?.pubKeyCount ?? updatedKeys.length
     );
   }
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -211,8 +211,8 @@ This way it is possible to get the current user's properties in the chaincode an
 
 ### Multisignature users and quorum
 
-Users may register more than one public key and specify how many signatures are required to authorize a transaction.
-During registration pass an array of keys and the `requiredSignatures` field:
+Users may register more than one public key. A majority of signatures is required to authorize a transaction.
+During registration pass an array of keys:
 
 ```typescript
 const { publicKey: pk1, privateKey: sk1 } = signatures.genKeyPair();
@@ -220,8 +220,7 @@ const { publicKey: pk2, privateKey: sk2 } = signatures.genKeyPair();
 
 const reg = await createValidSubmitDTO(RegisterUserDto, {
   user: "client|multisig",
-  publicKeys: [pk1, pk2],
-  requiredSignatures: 2
+  publicKeys: [pk1, pk2]
 });
 await pkContract.RegisterUser(reg.signed(adminKey));
 ```

--- a/docs/chaincode-deployment.md
+++ b/docs/chaincode-deployment.md
@@ -154,7 +154,6 @@ We highly recommend using the `@gala-chain/api` library for handling DTOs and si
 ```typescript
 const dto = new RegisterEthUser();
 dto.publicKeys = [<newUserPublicKey>];
-dto.requiredSignatures = 1;
 dto.sign(<gc-admin-key>);
 const payloadString = dto.serialize();
 ```

--- a/docs/concepts/identities-wallets-accounts.md
+++ b/docs/concepts/identities-wallets-accounts.md
@@ -76,8 +76,8 @@ async mintToken(ctx: GalaChainContext, dto: MintTokenDto) {
 
 ### Multisignature profiles
 
-Profiles may hold several public keys. When registering a user, supply all keys and the
-`requiredSignatures` value indicating how many unique signatures are needed on each transaction.
+Profiles may hold several public keys. When registering a user, supply all keys. A majority of unique
+signatures is required on each transaction.
 
 ```typescript
 const k1 = signatures.genKeyPair();
@@ -86,8 +86,7 @@ await pkContract.RegisterUser(
   (
     await createValidSubmitDTO(RegisterUserDto, {
       user: "client|multi",
-      publicKeys: [k1.publicKey, k2.publicKey],
-      requiredSignatures: 2
+      publicKeys: [k1.publicKey, k2.publicKey]
     })
   ).signed(adminKey)
 );


### PR DESCRIPTION
## Summary
- Drop `requiredSignatures` from public key registration DTOs
- Compute quorum as majority of keys when storing user profiles
- Update docs and tests for majority-based signature checking

## Testing
- `CI=1 npx nx test chain-api`
- `CI=1 npx nx test chain-connect`
- `CI=1 npx nx test chaincode`

------
https://chatgpt.com/codex/tasks/task_e_68befa0621808330b1b1bcb928da39e9