### PR TITLE
remove redundant payload hash test

### DIFF
--- a/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
+++ b/chain-api/src/utils/signatures/getPayloadToSign.spec.ts
@@ -12,8 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createHash } from "crypto";
-
 import { getPayloadToSign } from "./getPayloadToSign";
 
 describe("getPayloadToSign", () => {
@@ -42,23 +40,5 @@ describe("getPayloadToSign", () => {
 
     // Then
     expect(toSign).toEqual('{"c":8}');
-  });
-
-  it("should produce identical payload hashes whether signatures are present or not", () => {
-    // Given
-    const base = { c: 8 };
-    const withSignature = { ...base, signature: "to-be-ignored" };
-    const withSignatures = { ...base, signatures: ["to-be-ignored"] };
-
-    const hash = (s: string) => createHash("sha256").update(s).digest("hex");
-
-    // When
-    const baseHash = hash(getPayloadToSign(base));
-    const signatureHash = hash(getPayloadToSign(withSignature));
-    const signaturesHash = hash(getPayloadToSign(withSignatures));
-
-    // Then
-    expect(signatureHash).toEqual(baseHash);
-    expect(signaturesHash).toEqual(baseHash);
   });
 });

--- a/chain-api/src/utils/signatures/ton.ts
+++ b/chain-api/src/utils/signatures/ton.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NotImplementedError, ValidationFailedError } from "../error";
+import { ValidationFailedError } from "../error";
 import { getPayloadToSign } from "./getPayloadToSign";
 
 // verify if TON is supported


### PR DESCRIPTION
## Summary
- remove redundant payload hash test from getPayloadToSign
- drop unused NotImplementedError import in TON signature utilities

## Testing
- `CI=1 npx nx lint chain-api --output-style=stream --skip-nx-cache`
- `CI=1 npx nx test chain-api --output-style=stream --skip-nx-cache`


------
https://chatgpt.com/codex/tasks/task_e_68bf13bdf57883309f1fa01833a88197