### PR TITLE
chore(connect): remove multisig helpers

### DIFF
--- a/chain-connect/src/helpers.spec.ts
+++ b/chain-connect/src/helpers.spec.ts
@@ -12,9 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SigningClient } from "./customClients/SigningClient";
-import { calculatePersonalSignPrefix, composeMultisigDto, recoverPublicKeysFromDto } from "./helpers";
-import { SigningType } from "./types";
+import { calculatePersonalSignPrefix } from "./helpers";
 
 describe("calculatePersonalSignPrefix", () => {
   it("should return the correct prefix for a simple payload", () => {
@@ -77,18 +75,5 @@ describe("calculatePersonalSignPrefix", () => {
     const expectedPrefix = "\u0019Ethereum Signed Message:\n1062";
 
     expect(prefix).toBe(expectedPrefix);
-  });
-
-  it("should compose multisig dto and recover public keys", async () => {
-    const client1 = new SigningClient("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
-    const client2 = new SigningClient("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210");
-
-    const dto = { value: "test" };
-    const signed = await composeMultisigDto("TestMethod", dto, [client1, client2], SigningType.PERSONAL_SIGN);
-
-    expect(signed.signatures).toHaveLength(2);
-
-    const recovered = recoverPublicKeysFromDto(signed as any);
-    expect(recovered).toHaveLength(2);
   });
 });

--- a/chain-connect/src/helpers.ts
+++ b/chain-connect/src/helpers.ts
@@ -12,11 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChainCallDTO, SignatureDto, signatures } from "@gala-chain/api";
+import { signatures } from "@gala-chain/api";
 import { Eip1193Provider } from "ethers";
-
-import type { CustomClient } from "./GalaChainClient";
-import { SigningType } from "./types";
 
 /**
  * Calculates the personal sign prefix for Ethereum message signing.
@@ -37,46 +34,6 @@ export function calculatePersonalSignPrefix(payload: object): string {
   }
 
   return prefix;
-}
-
-/**
- * Signs a DTO with multiple clients, appending each signature to the DTO.
- * @param method - Chaincode method being signed
- * @param dto - DTO to sign
- * @param clients - Signing clients
- * @param signingType - Optional signing type override
- * @returns DTO with signatures from all clients
- */
-export async function composeMultisigDto<T extends object>(
-  method: string,
-  dto: T,
-  clients: CustomClient[],
-  signingType: SigningType = SigningType.SIGN_TYPED_DATA
-): Promise<T & { signatures: SignatureDto[] }> {
-  let signed: any = dto;
-  for (const client of clients) {
-    signed = await client.sign(method, signed, signingType);
-  }
-  return signed;
-}
-
-/**
- * Recovers public keys from all signatures present in the DTO.
- * @param dto - DTO containing signatures
- * @returns Array of recovered public keys in hex format
- */
-export function recoverPublicKeysFromDto(dto: ChainCallDTO): string[] {
-  const basePayload = { ...dto } as Record<string, unknown>;
-  delete basePayload.signatures;
-  delete basePayload.signature;
-  delete basePayload.signerPublicKey;
-  delete basePayload.signerAddress;
-
-  const sigs = dto.signatures ?? [];
-
-  return sigs.map((s) =>
-    signatures.recoverPublicKey(s.signature ?? "", basePayload, s.prefix ?? dto.prefix ?? "")
-  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove multisig helper functions from connect helpers
- drop multisig tests in helpers spec

## Testing
- `npx nx lint chain-connect`
- `npx nx test chain-connect --run-in-band --output-style=static`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f8dab508330bdaf5590840da66a