### PR TITLE
Remove per-transaction quorum configuration

### DIFF
--- a/chaincode/src/contracts/GalaTransaction.ts
+++ b/chaincode/src/contracts/GalaTransaction.ts
@@ -86,7 +86,6 @@ export interface CommonTransactionOptions<In extends ChainCallDTO, Out> {
   allowedOrgs?: string[];
   allowedRoles?: string[];
   allowedOriginChaincodes?: string[];
-  quorum?: number;
   apiMethodName?: string;
   sequence?: MethodAPI[];
   before?: GalaTransactionBeforeFn<In>;

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -313,49 +313,51 @@ describe("authorization", () => {
     return ContractClass;
   }
 
-  it("should enforce signature quorum", async () => {
-    const ContractClass = class extends GalaContract {
-      constructor() {
-        super("TestContract", "1.0.0");
-      }
-
-      public async Action(_ctx: GalaChainContext, _dto: ChainCallDTO): Promise<void> {
-        return;
-      }
-    };
-
-    const target = ContractClass.prototype;
-    const propertyKey = "Action";
-    const descriptor = Object.getOwnPropertyDescriptor(target, propertyKey) as PropertyDescriptor;
-
-    GalaTransaction({
-      type: SUBMIT,
-      in: ChainCallDTO,
-      out: "object",
-      enforceUniqueKey: true,
-      verifySignature: true,
-      quorum: 2
-    })(target, propertyKey, descriptor);
-    Object.defineProperty(target, propertyKey, descriptor);
-
-    const user = { ...ChainUser.withRandomKeys("quorum-user"), roles: [UserRole.SUBMIT] };
-    const f = fixture(ContractClass).caClientIdentity(anonymousUserId, defaultMsp).registeredUsers(user);
-
-    const dto = new ChainCallDTO();
-    dto.uniqueKey = "uniqueKey-quorum";
-    dto.sign(user.privateKey);
-
-    const resp = await f.contract.Action(f.ctx, dto);
-    expect(resp).toEqual(transactionErrorKey("UNAUTHORIZED"));
-  });
-
-  it("should accept sufficient quorum signatures", async () => {
+  it("should reject when not enough signatures", async () => {
     class QuorumContract extends GalaContract {
       constructor() {
         super("QuorumContract", "1.0.0");
       }
 
-      @Submit({ in: SubmitCallDTO, out: "object", quorum: 2 })
+      @Submit({ in: SubmitCallDTO, out: "object" })
+      public async Action(_ctx: GalaChainContext, _dto: SubmitCallDTO): Promise<void> {
+        return;
+      }
+    }
+
+    const chaincode = new TestChaincode([QuorumContract, PublicKeyContract]);
+
+    const kp1 = signatures.genKeyPair();
+    const kp2 = signatures.genKeyPair();
+    const alias = "client|quorum" as UserAlias;
+
+    const regDto = await createValidSubmitDTO(RegisterUserDto, {
+      user: alias,
+      publicKeys: [kp1.publicKey, kp2.publicKey]
+    });
+    const regResp = await chaincode.invoke(
+      "PublicKeyContract:RegisterUser",
+      regDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string)
+    );
+    expect(regResp).toEqual(transactionSuccess());
+
+    const dto = new SubmitCallDTO();
+    dto.uniqueKey = "uniqueKey-quorum-fail";
+    dto.signerPublicKey = kp1.publicKey;
+    dto.sign(kp1.privateKey);
+
+    chaincode.setCallingUser(alias);
+    const resp = await chaincode.invoke("QuorumContract:Action", dto);
+    expect(resp).toEqual(transactionErrorKey("UNAUTHORIZED"));
+  });
+
+  it("should accept sufficient signatures", async () => {
+    class QuorumContract extends GalaContract {
+      constructor() {
+        super("QuorumContract", "1.0.0");
+      }
+
+      @Submit({ in: SubmitCallDTO, out: "object" })
       public async Action(_ctx: GalaChainContext, _dto: SubmitCallDTO): Promise<void> {
         return;
       }

--- a/chaincode/src/contracts/authorize.ts
+++ b/chaincode/src/contracts/authorize.ts
@@ -85,7 +85,6 @@ export interface AuthorizeOptions {
   allowedOrgs?: string[];
   allowedRoles?: string[];
   allowedOriginChaincodes?: string[];
-  quorum?: number;
 }
 
 export interface QuorumInfo {
@@ -102,7 +101,7 @@ export async function authorize(ctx: GalaChainContext, options: AuthorizeOptions
 
   if (quorum) {
     const user = ctx.callingUserProfile;
-    const requiredSignatures = Math.max(user.requiredSignatures, options.quorum ?? 1);
+    const requiredSignatures = Math.max(user.requiredSignatures, 1);
     if (quorum.signedByKeys.length < requiredSignatures) {
       throw new UnauthorizedError(
         `Insufficient signatures: got ${quorum.signedByKeys.length}, required ${requiredSignatures}.`,

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -209,7 +209,7 @@ The `ctx.callingUserRoles` property will contain the user's assigned roles.
 
 This way it is possible to get the current user's properties in the chaincode and use them in the business logic.
 
-### Multisignature users and quorum
+### Multisignature users
 
 Users may register more than one public key. A majority of signatures is required to authorize a transaction.
 During registration pass an array of keys:
@@ -233,8 +233,7 @@ dto.sign(sk1);
 dto.sign(sk2); // dto.signatures = [{ signerPublicKey: pk1, signature: "..." }, { signerPublicKey: pk2, signature: "..." }]
 ```
 
-Chaincode enforces the user profile's `requiredSignatures` or an explicit `quorum` specified on
-`@Submit`/`@Evaluate` via the `GalaTransaction` decorator. If a transaction provides fewer unique
+Chaincode enforces the user profile's `requiredSignatures`. If a transaction provides fewer unique
 signatures than required it fails with `UNAUTHORIZED`; duplicate keys are rejected with
 `DUPLICATE_SIGNER_PUBLIC_KEY`.
 


### PR DESCRIPTION
## Summary
- drop `quorum` option from transaction and authorization settings
- enforce multisig solely via user profile `requiredSignatures`
- update docs and tests accordingly

## Testing
- `npx nx test chaincode` *(fails: terminal crashed)*
- `npx jest chaincode/src/contracts/authorize.spec.ts --runInBand` *(fails: Jest: Failed to parse the TypeScript config file /workspace/sdk/jest.config.ts: TS2724)*

------
https://chatgpt.com/codex/tasks/task_e_68bf29a326c88330b45c5dd7444c3fe4