### PR TITLE
Reject multisig for public key updates and alias resolution

### DIFF
--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -15,6 +15,7 @@
 import {
   ChainCallDTO,
   ChainObject,
+  NotImplementedError,
   PK_INDEX_KEY,
   PublicKey,
   SigningScheme,
@@ -277,13 +278,7 @@ export class PublicKeyService {
     await PublicKeyService.putPublicKey(ctx, publicKeys, userAlias, signing);
 
     // for the new flow, we need to store the user profile separately
-    await PublicKeyService.putUserProfile(
-      ctx,
-      ethAddress,
-      userAlias,
-      signing,
-      publicKeys.length
-    );
+    await PublicKeyService.putUserProfile(ctx, ethAddress, userAlias, signing, publicKeys.length);
 
     return userAlias;
   }
@@ -295,6 +290,12 @@ export class PublicKeyService {
     signing: SigningScheme
   ): Promise<void> {
     const userAlias = ctx.callingUser;
+
+    if (ctx.callingUserProfile.requiredSignatures > 1) {
+      throw new NotImplementedError("UpdatePublicKey is not supported for multisig users", {
+        alias: userAlias
+      });
+    }
 
     // fetch old public key for finding old user profile
     const oldPublicKey = await PublicKeyService.getPublicKey(ctx, ctx.callingUser);

--- a/chaincode/src/services/resolveUserAlias.spec.ts
+++ b/chaincode/src/services/resolveUserAlias.spec.ts
@@ -1,0 +1,41 @@
+import { SigningScheme } from "@gala-chain/api";
+
+import { resolveUserAlias } from "./resolveUserAlias";
+import { PublicKeyService } from "./PublicKeyService";
+
+describe("resolveUserAlias", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws when alias belongs to multisig profile", async () => {
+    const ctx = {} as any;
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue({
+      publicKey: "pk",
+      signing: SigningScheme.ETH
+    } as any);
+    jest.spyOn(PublicKeyService, "getUserAddress").mockReturnValue("0xabc");
+    jest.spyOn(PublicKeyService, "getUserProfile").mockResolvedValue({
+      requiredSignatures: 2
+    } as any);
+
+    await expect(resolveUserAlias(ctx, "client|ms1")).rejects.toThrow(
+      "resolveUserAlias is not supported for multisig profiles"
+    );
+  });
+
+  it("returns alias when not multisig", async () => {
+    const ctx = {} as any;
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue({
+      publicKey: "pk",
+      signing: SigningScheme.ETH
+    } as any);
+    jest.spyOn(PublicKeyService, "getUserAddress").mockReturnValue("0xabc");
+    jest.spyOn(PublicKeyService, "getUserProfile").mockResolvedValue({
+      requiredSignatures: 1,
+      alias: "client|user"
+    } as any);
+
+    await expect(resolveUserAlias(ctx, "client|user")).resolves.toBe("client|user");
+  });
+});

--- a/chaincode/src/services/resolveUserAlias.ts
+++ b/chaincode/src/services/resolveUserAlias.ts
@@ -19,7 +19,8 @@ import {
   ValidationFailedError,
   asValidUserAlias,
   signatures,
-  validateUserRef
+  validateUserRef,
+  SigningScheme
 } from "@gala-chain/api";
 
 import { GalaChainContext } from "../types";
@@ -36,6 +37,8 @@ export async function resolveUserAlias(ctx: GalaChainContext, userRef: string): 
     if (userRef.startsWith("eth|")) {
       return await resolveAliasFromEthAddress(ctx, userRef.slice(4));
     }
+
+    await ensureAliasNotMultisig(ctx, userRef as UserAlias);
 
     return userRef as UserAlias;
   }
@@ -58,4 +61,18 @@ async function resolveAliasFromEthAddress(ctx: GalaChainContext, rawEthAddress: 
   }
   const actualAlias = userProfile?.alias ?? asValidUserAlias(`eth|${ethAddress}`);
   return actualAlias;
+}
+
+async function ensureAliasNotMultisig(ctx: GalaChainContext, alias: UserAlias): Promise<void> {
+  const pk = await PublicKeyService.getPublicKey(ctx, alias);
+  if (pk === undefined) {
+    return;
+  }
+  const address = PublicKeyService.getUserAddress(pk.publicKey, pk.signing as SigningScheme);
+  const userProfile = await PublicKeyService.getUserProfile(ctx, address);
+  if (userProfile?.requiredSignatures !== undefined && userProfile.requiredSignatures > 1) {
+    throw new NotImplementedError("resolveUserAlias is not supported for multisig profiles", {
+      userRef: alias
+    });
+  }
 }

--- a/chaincode/src/services/resolveUserAlias.ts
+++ b/chaincode/src/services/resolveUserAlias.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 import {
+  NotImplementedError,
   UserAlias,
   UserRefValidationResult,
   ValidationFailedError,
@@ -50,6 +51,11 @@ export async function resolveUserAlias(ctx: GalaChainContext, userRef: string): 
 async function resolveAliasFromEthAddress(ctx: GalaChainContext, rawEthAddress: string): Promise<UserAlias> {
   const ethAddress = signatures.normalizeEthAddress(rawEthAddress);
   const userProfile = await PublicKeyService.getUserProfile(ctx, ethAddress);
+  if (userProfile?.requiredSignatures !== undefined && userProfile.requiredSignatures > 1) {
+    throw new NotImplementedError("resolveUserAlias is not supported for multisig profiles", {
+      userRef: rawEthAddress
+    });
+  }
   const actualAlias = userProfile?.alias ?? asValidUserAlias(`eth|${ethAddress}`);
   return actualAlias;
 }


### PR DESCRIPTION
## Summary
- prevent UpdatePublicKey from running for multisig users
- disallow resolveUserAlias on multisig profiles

## Testing
- `npx jest src/services/PublicKeyService.spec.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bf4a1079148330b4868dac2c035b04