### PR TITLE
Reject multisig for public key updates and alias resolution

### DIFF
--- a/chaincode/src/services/resolveUserAlias.spec.ts
+++ b/chaincode/src/services/resolveUserAlias.spec.ts
@@ -1,0 +1,41 @@
+import { SigningScheme } from "@gala-chain/api";
+
+import { resolveUserAlias } from "./resolveUserAlias";
+import { PublicKeyService } from "./PublicKeyService";
+
+describe("resolveUserAlias", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("throws when alias belongs to multisig profile", async () => {
+    const ctx = {} as any;
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue({
+      publicKey: "pk",
+      signing: SigningScheme.ETH
+    } as any);
+    jest.spyOn(PublicKeyService, "getUserAddress").mockReturnValue("0xabc");
+    jest.spyOn(PublicKeyService, "getUserProfile").mockResolvedValue({
+      requiredSignatures: 2
+    } as any);
+
+    await expect(resolveUserAlias(ctx, "client|ms1")).rejects.toThrow(
+      "resolveUserAlias is not supported for multisig profiles"
+    );
+  });
+
+  it("returns alias when not multisig", async () => {
+    const ctx = {} as any;
+    jest.spyOn(PublicKeyService, "getPublicKey").mockResolvedValue({
+      publicKey: "pk",
+      signing: SigningScheme.ETH
+    } as any);
+    jest.spyOn(PublicKeyService, "getUserAddress").mockReturnValue("0xabc");
+    jest.spyOn(PublicKeyService, "getUserProfile").mockResolvedValue({
+      requiredSignatures: 1,
+      alias: "client|user"
+    } as any);
+
+    await expect(resolveUserAlias(ctx, "client|user")).resolves.toBe("client|user");
+  });
+});

--- a/chaincode/src/services/resolveUserAlias.ts
+++ b/chaincode/src/services/resolveUserAlias.ts
@@ -19,7 +19,8 @@ import {
   ValidationFailedError,
   asValidUserAlias,
   signatures,
-  validateUserRef
+  validateUserRef,
+  SigningScheme
 } from "@gala-chain/api";
 
 import { GalaChainContext } from "../types";
@@ -36,6 +37,8 @@ export async function resolveUserAlias(ctx: GalaChainContext, userRef: string): 
     if (userRef.startsWith("eth|")) {
       return await resolveAliasFromEthAddress(ctx, userRef.slice(4));
     }
+
+    await ensureAliasNotMultisig(ctx, userRef as UserAlias);
 
     return userRef as UserAlias;
   }
@@ -58,4 +61,18 @@ async function resolveAliasFromEthAddress(ctx: GalaChainContext, rawEthAddress: 
   }
   const actualAlias = userProfile?.alias ?? asValidUserAlias(`eth|${ethAddress}`);
   return actualAlias;
+}
+
+async function ensureAliasNotMultisig(ctx: GalaChainContext, alias: UserAlias): Promise<void> {
+  const pk = await PublicKeyService.getPublicKey(ctx, alias);
+  if (pk === undefined) {
+    return;
+  }
+  const address = PublicKeyService.getUserAddress(pk.publicKey, pk.signing as SigningScheme);
+  const userProfile = await PublicKeyService.getUserProfile(ctx, address);
+  if (userProfile?.requiredSignatures !== undefined && userProfile.requiredSignatures > 1) {
+    throw new NotImplementedError("resolveUserAlias is not supported for multisig profiles", {
+      userRef: alias
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- check existing alias profiles to block multisig users
- add tests around multisig alias handling

## Testing
- `npx jest src/services/PublicKeyService.spec.ts --runInBand`
- `npx jest src/services/resolveUserAlias.spec.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c04a9648548330a3e6f0ae475cb45d