### PR TITLE
feat: store multiple user profiles

### DIFF
--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -267,23 +267,30 @@ export class PublicKeyService {
       }
     }
 
-    // If User Profile already exists on chain for this ethereum address, we should not allow registering the same user again
-    const existingUserProfile = await PublicKeyService.getUserProfile(ctx, ethAddress);
-    if (existingUserProfile !== undefined) {
-      throw new ProfileExistsError(ethAddress, existingUserProfile.alias);
+    // derive addresses from provided public keys
+    const derivedAddresses = publicKeys.map((pk) => PublicKeyService.getUserAddress(pk, signing));
+    let uniqueAddresses = Array.from(new Set(derivedAddresses));
+
+    // maintain backwards compatibility with single provided address
+    if (publicKeys.length === 1 && ethAddress) {
+      uniqueAddresses = [ethAddress];
+    }
+
+    // If any User Profile already exists on chain for derived address, do not allow registering again
+    for (const address of uniqueAddresses) {
+      const existingUserProfile = await PublicKeyService.getUserProfile(ctx, address);
+      if (existingUserProfile !== undefined) {
+        throw new ProfileExistsError(address, existingUserProfile.alias);
+      }
     }
 
     // supports legacy flow (required for backwards compatibility)
     await PublicKeyService.putPublicKey(ctx, publicKeys, userAlias, signing);
 
-    // for the new flow, we need to store the user profile separately
-    await PublicKeyService.putUserProfile(
-      ctx,
-      ethAddress,
-      userAlias,
-      signing,
-      publicKeys.length
-    );
+    // store the user profile for each unique address
+    for (const address of uniqueAddresses) {
+      await PublicKeyService.putUserProfile(ctx, address, userAlias, signing, publicKeys.length);
+    }
 
     return userAlias;
   }


### PR DESCRIPTION
## Summary
- derive and deduplicate addresses from all provided public keys
- write user profiles for each unique address with correct signature thresholds

## Testing
- `npx nx lint chaincode` *(fails: 7 errors, 59 warnings)*
- `CI=true npx nx test chaincode` *(fails: PublicKeyContract spec and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c05737b2008330b73a419048bebbb4