### PR TITLE
refactor: simplify public key registration

### DIFF
--- a/chaincode/src/contracts/PublicKeyContract.ts
+++ b/chaincode/src/contracts/PublicKeyContract.ts
@@ -88,8 +88,9 @@ export class PublicKeyContract extends GalaContract {
     PublicKeyContract.ensurePublicKeys(dto.publicKeys);
 
     const userAlias = dto.user;
+    const signing = dto.signing ?? SigningScheme.ETH;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, signing);
   }
 
   @Submit({
@@ -103,7 +104,7 @@ export class PublicKeyContract extends GalaContract {
     const ethAddress = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.ETH);
     const userAlias = `eth|${ethAddress}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.ETH);
   }
 
   @Submit({
@@ -117,7 +118,7 @@ export class PublicKeyContract extends GalaContract {
     const address = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.TON);
     const userAlias = `ton|${address}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.TON);
   }
 
   @Submit({

--- a/chaincode/src/contracts/PublicKeyContract.ts
+++ b/chaincode/src/contracts/PublicKeyContract.ts
@@ -25,8 +25,7 @@ import {
   UpdateUserRolesDto,
   UserAlias,
   UserProfile,
-  ValidationFailedError,
-  signatures
+  ValidationFailedError
 } from "@gala-chain/api";
 import { Info } from "fabric-contract-api";
 
@@ -88,17 +87,9 @@ export class PublicKeyContract extends GalaContract {
     }
     PublicKeyContract.ensurePublicKeys(dto.publicKeys);
 
-    const providedPkHex = signatures.getNonCompactHexPublicKey(dto.publicKeys[0]);
-    const ethAddress = signatures.getEthAddress(providedPkHex);
     const userAlias = dto.user;
 
-    return PublicKeyService.registerUser(
-      ctx,
-      dto.publicKeys,
-      ethAddress,
-      userAlias,
-      SigningScheme.ETH
-    );
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
   }
 
   @Submit({
@@ -109,17 +100,10 @@ export class PublicKeyContract extends GalaContract {
   })
   public async RegisterEthUser(ctx: GalaChainContext, dto: RegisterEthUserDto): Promise<string> {
     PublicKeyContract.ensurePublicKeys(dto.publicKeys);
-    const providedPkHex = signatures.getNonCompactHexPublicKey(dto.publicKeys[0]);
-    const ethAddress = signatures.getEthAddress(providedPkHex);
+    const ethAddress = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.ETH);
     const userAlias = `eth|${ethAddress}` as UserAlias;
 
-    return PublicKeyService.registerUser(
-      ctx,
-      dto.publicKeys,
-      ethAddress,
-      userAlias,
-      SigningScheme.ETH
-    );
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
   }
 
   @Submit({
@@ -130,17 +114,10 @@ export class PublicKeyContract extends GalaContract {
   })
   public async RegisterTonUser(ctx: GalaChainContext, dto: RegisterTonUserDto): Promise<string> {
     PublicKeyContract.ensurePublicKeys(dto.publicKeys);
-    const publicKey = dto.publicKeys[0];
-    const address = signatures.ton.getTonAddress(Buffer.from(publicKey, "base64"));
+    const address = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.TON);
     const userAlias = `ton|${address}` as UserAlias;
 
-    return PublicKeyService.registerUser(
-      ctx,
-      dto.publicKeys,
-      address,
-      userAlias,
-      SigningScheme.TON
-    );
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
   }
 
   @Submit({

--- a/chaincode/src/contracts/authenticate.multisig.spec.ts
+++ b/chaincode/src/contracts/authenticate.multisig.spec.ts
@@ -15,6 +15,7 @@
 import {
   GetMyProfileDto,
   RegisterUserDto,
+  SigningScheme,
   UserAlias,
   createValidSubmitDTO,
   signatures
@@ -34,7 +35,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -61,7 +63,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -84,7 +87,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: user.alias,
-      publicKeys: [user.publicKey, other.publicKey]
+      publicKeys: [user.publicKey, other.publicKey],
+      signing: SigningScheme.ETH
     });
     const regSigned = regDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
     const regResp = await chaincode.invoke("PublicKeyContract:RegisterUser", regSigned);

--- a/chaincode/src/contracts/authenticate.testutils.spec.ts
+++ b/chaincode/src/contracts/authenticate.testutils.spec.ts
@@ -58,7 +58,8 @@ export async function createRegisteredUser(chaincode: TestChaincode): Promise<Us
   const { alias, privateKey, publicKey, ethAddress } = await createUser();
   const dto = await createValidSubmitDTO(RegisterUserDto, {
     user: alias,
-    publicKeys: [publicKey]
+    publicKeys: [publicKey],
+    signing: SigningScheme.ETH
   });
   const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
   const response = await chaincode.invoke("PublicKeyContract:RegisterUser", signedDto);

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -16,6 +16,7 @@ import {
   ChainCallDTO,
   ChainUser,
   RegisterUserDto,
+  SigningScheme,
   SubmitCallDTO,
   UserAlias,
   UserProfile,
@@ -369,7 +370,8 @@ describe("authorization", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",

--- a/chaincode/src/services/PublicKeyService.spec.ts
+++ b/chaincode/src/services/PublicKeyService.spec.ts
@@ -65,13 +65,7 @@ it("should put user profiles for all unique addresses derived from public keys",
   const pk2 = users.random().publicKey;
   const alias = "client|multi" as UserAlias;
 
-  await PublicKeyService.registerUser(
-    ctx,
-    [pk1, pk2],
-    "0000000000000000000000000000000000000000",
-    alias,
-    SigningScheme.ETH
-  );
+  await PublicKeyService.registerUser(ctx, [pk1, pk2], alias);
 
   await ctx.stub.flushWrites();
 

--- a/chaincode/src/services/PublicKeyService.spec.ts
+++ b/chaincode/src/services/PublicKeyService.spec.ts
@@ -65,7 +65,7 @@ it("should put user profiles for all unique addresses derived from public keys",
   const pk2 = users.random().publicKey;
   const alias = "client|multi" as UserAlias;
 
-  await PublicKeyService.registerUser(ctx, [pk1, pk2], alias);
+  await PublicKeyService.registerUser(ctx, [pk1, pk2], alias, SigningScheme.ETH);
 
   await ctx.stub.flushWrites();
 

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -247,9 +247,9 @@ export class PublicKeyService {
   public static async registerUser(
     ctx: GalaChainContext,
     publicKeys: string[],
-    userAlias: UserAlias
+    userAlias: UserAlias,
+    signing: SigningScheme
   ): Promise<string> {
-    const signing = userAlias.startsWith("ton|") ? SigningScheme.TON : SigningScheme.ETH;
     const currPublicKey = await PublicKeyService.getPublicKey(ctx, userAlias);
     const firstPk = publicKeys[0];
     const providedPk =

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -247,10 +247,9 @@ export class PublicKeyService {
   public static async registerUser(
     ctx: GalaChainContext,
     publicKeys: string[],
-    ethAddress: string,
-    userAlias: UserAlias,
-    signing: SigningScheme
+    userAlias: UserAlias
   ): Promise<string> {
+    const signing = userAlias.startsWith("ton|") ? SigningScheme.TON : SigningScheme.ETH;
     const currPublicKey = await PublicKeyService.getPublicKey(ctx, userAlias);
     const firstPk = publicKeys[0];
     const providedPk =
@@ -270,10 +269,7 @@ export class PublicKeyService {
     const derivedAddresses = publicKeys.map((pk) =>
       PublicKeyService.getUserAddress(pk, signing)
     );
-    const uniqueAddresses =
-      publicKeys.length > 1
-        ? Array.from(new Set(derivedAddresses))
-        : [ethAddress ?? derivedAddresses[0]];
+    const uniqueAddresses = Array.from(new Set(derivedAddresses));
 
     for (const address of uniqueAddresses) {
       const existingUserProfile = await PublicKeyService.getUserProfile(ctx, address);


### PR DESCRIPTION
## Summary
- register users using only public keys and aliases
- derive user addresses inside PublicKeyService
- align tests with new registration signature

## Testing
- `CI=1 npx nx test chaincode` *(fails: NX Running target test for project chaincode failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c06569c5a88330bad270b2bbd00ca7