### PR TITLE
fix: require explicit signing for registration

### DIFF
--- a/chaincode/src/contracts/PublicKeyContract.ts
+++ b/chaincode/src/contracts/PublicKeyContract.ts
@@ -88,8 +88,9 @@ export class PublicKeyContract extends GalaContract {
     PublicKeyContract.ensurePublicKeys(dto.publicKeys);
 
     const userAlias = dto.user;
+    const signing = dto.signing ?? SigningScheme.ETH;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, signing);
   }
 
   @Submit({
@@ -103,7 +104,7 @@ export class PublicKeyContract extends GalaContract {
     const ethAddress = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.ETH);
     const userAlias = `eth|${ethAddress}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.ETH);
   }
 
   @Submit({
@@ -117,7 +118,7 @@ export class PublicKeyContract extends GalaContract {
     const address = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.TON);
     const userAlias = `ton|${address}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias);
+    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.TON);
   }
 
   @Submit({

--- a/chaincode/src/contracts/authenticate.multisig.spec.ts
+++ b/chaincode/src/contracts/authenticate.multisig.spec.ts
@@ -15,6 +15,7 @@
 import {
   GetMyProfileDto,
   RegisterUserDto,
+  SigningScheme,
   UserAlias,
   createValidSubmitDTO,
   signatures
@@ -34,7 +35,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -61,7 +63,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",
@@ -84,7 +87,8 @@ describe("authenticate multisig", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: user.alias,
-      publicKeys: [user.publicKey, other.publicKey]
+      publicKeys: [user.publicKey, other.publicKey],
+      signing: SigningScheme.ETH
     });
     const regSigned = regDto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
     const regResp = await chaincode.invoke("PublicKeyContract:RegisterUser", regSigned);

--- a/chaincode/src/contracts/authenticate.testutils.spec.ts
+++ b/chaincode/src/contracts/authenticate.testutils.spec.ts
@@ -58,7 +58,8 @@ export async function createRegisteredUser(chaincode: TestChaincode): Promise<Us
   const { alias, privateKey, publicKey, ethAddress } = await createUser();
   const dto = await createValidSubmitDTO(RegisterUserDto, {
     user: alias,
-    publicKeys: [publicKey]
+    publicKeys: [publicKey],
+    signing: SigningScheme.ETH
   });
   const signedDto = dto.signed(process.env.DEV_ADMIN_PRIVATE_KEY as string);
   const response = await chaincode.invoke("PublicKeyContract:RegisterUser", signedDto);

--- a/chaincode/src/contracts/authorize.spec.ts
+++ b/chaincode/src/contracts/authorize.spec.ts
@@ -16,6 +16,7 @@ import {
   ChainCallDTO,
   ChainUser,
   RegisterUserDto,
+  SigningScheme,
   SubmitCallDTO,
   UserAlias,
   UserProfile,
@@ -369,7 +370,8 @@ describe("authorization", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await chaincode.invoke(
       "PublicKeyContract:RegisterUser",

--- a/chaincode/src/services/PublicKeyService.spec.ts
+++ b/chaincode/src/services/PublicKeyService.spec.ts
@@ -65,7 +65,7 @@ it("should put user profiles for all unique addresses derived from public keys",
   const pk2 = users.random().publicKey;
   const alias = "client|multi" as UserAlias;
 
-  await PublicKeyService.registerUser(ctx, [pk1, pk2], alias);
+  await PublicKeyService.registerUser(ctx, [pk1, pk2], alias, SigningScheme.ETH);
 
   await ctx.stub.flushWrites();
 

--- a/chaincode/src/services/PublicKeyService.ts
+++ b/chaincode/src/services/PublicKeyService.ts
@@ -247,9 +247,9 @@ export class PublicKeyService {
   public static async registerUser(
     ctx: GalaChainContext,
     publicKeys: string[],
-    userAlias: UserAlias
+    userAlias: UserAlias,
+    signing: SigningScheme
   ): Promise<string> {
-    const signing = userAlias.startsWith("ton|") ? SigningScheme.TON : SigningScheme.ETH;
     const currPublicKey = await PublicKeyService.getPublicKey(ctx, userAlias);
     const firstPk = publicKeys[0];
     const providedPk =


### PR DESCRIPTION
## Summary
- respect signing scheme in PublicKeyService.registerUser instead of inferring from alias
- pass signing scheme through PublicKeyContract registration methods
- adjust tests for explicit signing and multisig updates

## Testing
- `CI=1 npx nx test chaincode --skip-nx-cache --runInBand --silent` *(fails: environment could not complete tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c07797780083308129ccd091596484