### PR TITLE
refactor: make PublicKey union type single line

### DIFF
--- a/chain-api/src/types/PublicKey.ts
+++ b/chain-api/src/types/PublicKey.ts
@@ -37,9 +37,7 @@ export class PublicKey extends ChainObject {
     return super.serialize();
   }
 
-  public static from(
-    object: string | Record<string, unknown> | Record<string, unknown>[]
-  ): PublicKey {
+  public static from(object: string | Record<string, unknown> | Record<string, unknown>[]): PublicKey {
     const pk = ChainObject.deserialize<PublicKey>(PublicKey, object);
     if (pk.publicKeys === undefined || pk.publicKeys.length === 0) {
       if (pk.publicKey !== undefined) {


### PR DESCRIPTION
## Summary
- simplify `PublicKey.from` parameter union onto one line

## Testing
- `npx prettier chain-api/src/types/PublicKey.ts -w`
- `npx eslint chain-api/src/types/PublicKey.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c18f7170248330ac2a81148634c481