### PR TITLE
fix: remove unused variables

### DIFF
--- a/chain-api/src/ethers/errors.ts
+++ b/chain-api/src/ethers/errors.ts
@@ -162,7 +162,7 @@ export interface EthersError<T extends ErrorCode = ErrorCode> extends Error {
   /**
    *  The string error code.
    */
-  code: ErrorCode;
+  code: T;
 
   /**
    *  A short message describing the error, with minimal additional

--- a/chain-api/src/ethers/utils/utf8.ts
+++ b/chain-api/src/ethers/utils/utf8.ts
@@ -94,6 +94,8 @@ function errorFunc(
   output: Array<number>,
   badCodepoint?: number
 ): number {
+  void output;
+  void badCodepoint;
   assertArgument(false, `invalid codepoint at offset ${offset}; ${reason}`, "bytes", bytes);
 }
 
@@ -104,6 +106,8 @@ function ignoreFunc(
   output: Array<number>,
   badCodepoint?: number
 ): number {
+  void output;
+  void badCodepoint;
   // If there is an invalid prefix (including stray continuation), skip any additional continuation bytes
   if (reason === "BAD_PREFIX" || reason === "UNEXPECTED_CONTINUE") {
     let i = 0;

--- a/chain-api/src/types/TokenClass.ts
+++ b/chain-api/src/types/TokenClass.ts
@@ -31,7 +31,6 @@ import { ChainKey } from "../utils";
 import { BigNumberIsPositive, BigNumberProperty, IsUserAlias } from "../validators";
 import { ChainObject } from "./ChainObject";
 import { UserAlias } from "./UserAlias";
-import { UserRef } from "./UserRef";
 import { GC_NETWORK_ID } from "./contract";
 import { ChainCallDTO } from "./dtos";
 

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -21,12 +21,8 @@ import {
   IsOptional,
   Max,
   Min,
-  MinLength,
   ValidateNested,
-  ValidationArguments,
   ValidationError,
-  ValidationOptions,
-  registerDecorator,
   validate
 } from "class-validator";
 import { JSONSchema } from "class-validator-jsonschema";
@@ -596,29 +592,6 @@ export class DryRunResultDto extends ChainCallDTO {
    * for more details on the importantce of Read/Write sets.
    */
   public deletes: Record<string, true>;
-}
-
-function MaxArrayLength(property: string, validationOptions?: ValidationOptions) {
-  return function (object: object, propertyName: string) {
-    registerDecorator({
-      name: "maxArrayLength",
-      target: (object as Record<string, unknown>).constructor,
-      propertyName,
-      constraints: [property],
-      options: validationOptions,
-      validator: {
-        validate(value: unknown, args: ValidationArguments) {
-          const [relatedPropertyName] = args.constraints;
-          const relatedValue = (args.object as Record<string, unknown>)[relatedPropertyName];
-          return typeof value === "number" && Array.isArray(relatedValue) && value <= relatedValue.length;
-        },
-        defaultMessage(args: ValidationArguments) {
-          const [relatedPropertyName] = args.constraints;
-          return `${args.property} must not be greater than ${relatedPropertyName}.length`;
-        }
-      }
-    });
-  };
 }
 
 /**

--- a/chain-api/src/utils/generate-schema.ts
+++ b/chain-api/src/utils/generate-schema.ts
@@ -39,14 +39,14 @@ function customTargetConstructorToSchema(classType: ClassConstructor) {
         };
         return schemaObj;
       },
-      ["IsUserAliasConstraint"]: (meta) => {
+      ["IsUserAliasConstraint"]: () => {
         return {
           type: "string",
           description:
             "Allowed value is string following the format of 'client|<user-id>', or 'eth|<checksumed-eth-addr>', or valid system-level username."
         };
       },
-      ["IsUserRefConstraint"]: (meta) => {
+      ["IsUserRefConstraint"]: () => {
         return {
           type: "string",
           description:


### PR DESCRIPTION
## Summary
- remove or reference unused function parameters in UTF-8 utilities
- remove unused imports and helper functions
- use generic code property in `EthersError`

## Testing
- `npx eslint --max-warnings=0 chain-api/src/ethers/errors.ts chain-api/src/ethers/utils/utf8.ts chain-api/src/types/TokenClass.ts chain-api/src/types/dtos.ts chain-api/src/utils/generate-schema.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c1b0026e30833097fbb60f60bf1240