### PR TITLE
fix(chain-api): make roles optional in UserProfile

### DIFF
--- a/chain-api/src/types/UserProfile.ts
+++ b/chain-api/src/types/UserProfile.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ArrayNotEmpty, IsInt, IsNotEmpty, IsString, Min, ValidateIf } from "class-validator";
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min, ValidateIf } from "class-validator";
 import { JSONSchema } from "class-validator-jsonschema";
 
 import { IsUserAlias } from "../validators";
@@ -57,9 +57,9 @@ export class UserProfile extends ChainObject {
       .sort()
       .join(", ")}, but you can use arbitrary strings to define your own roles.`
   })
+  @IsOptional()
   @IsString({ each: true })
-  @ArrayNotEmpty()
-  roles: string[];
+  roles?: string[];
 
   @JSONSchema({
     description: `Number of stored public keys for the user.`


### PR DESCRIPTION
## Summary
- make `UserProfile.roles` optional again for backward compatibility

## Testing
- `npx nx lint chain-api`
- `CI=true npx nx test chain-api`


------
https://chatgpt.com/codex/tasks/task_e_68c20dcfce38833081fc28ab9d059eed