### PR TITLE
fix(chain-api): make pubKeyCount optional

### DIFF
--- a/chain-api/src/types/UserProfile.ts
+++ b/chain-api/src/types/UserProfile.ts
@@ -64,22 +64,24 @@ export class UserProfile extends ChainObject {
   @JSONSchema({
     description: `Number of stored public keys for the user.`
   })
+  @IsOptional()
   @IsInt()
   @Min(0)
-  pubKeyCount: number;
+  pubKeyCount?: number;
 
   @JSONSchema({
     description: `Minimum number of signatures required for authorization.`
   })
+  @IsOptional()
   @IsInt()
   @Min(1)
-  requiredSignatures: number;
+  requiredSignatures?: number;
 }
 
 export const UP_INDEX_KEY = "GCUP";
 
 export type UserProfileWithRoles = UserProfile & {
   roles: string[];
-  pubKeyCount: number;
-  requiredSignatures: number;
+  pubKeyCount?: number;
+  requiredSignatures?: number;
 };


### PR DESCRIPTION
## Summary
- make quorum fields optional in UserProfile

## Testing
- `npx nx test chain-api`

------
https://chatgpt.com/codex/tasks/task_e_68c2144d4cfc8330b35fc31675547a7d