### PR TITLE
fix: default optional profile values

### DIFF
--- a/chaincode/src/contracts/GalaTransaction.ts
+++ b/chaincode/src/contracts/GalaTransaction.ts
@@ -198,7 +198,10 @@ function GalaTransaction<In extends ChainCallDTO, Out>(
         } else if (options?.verifySignature || dto?.signature !== undefined) {
           const auth = await authenticate(ctx, dto);
           ctx.callingUserData = auth;
-          quorumInfo = { signedByKeys: auth.signedByKeys, pubKeyCount: auth.pubKeyCount };
+          quorumInfo = {
+            signedByKeys: auth.signedByKeys,
+            pubKeyCount: auth.pubKeyCount ?? 1
+          };
         } else {
           // it means a request where authorization is not required. If there is org-based authorization,
           // default roles are applied. If not, then only evaluate is possible. Alias is intentionally

--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -123,14 +123,18 @@ export async function authenticate(
   }
 
   const profile = authResults[0].profile;
+  const pubKeyCount = profile.pubKeyCount ?? 1;
+  const requiredSignatures =
+    profile.requiredSignatures ?? Math.floor(pubKeyCount / 2) + 1;
+
   return {
     alias: profile.alias,
     ethAddress: profile.ethAddress,
     tonAddress: profile.tonAddress,
     roles: profile.roles,
     signedByKeys: keys,
-    pubKeyCount: profile.pubKeyCount,
-    requiredSignatures: profile.requiredSignatures
+    pubKeyCount,
+    requiredSignatures
   };
 }
 

--- a/chaincode/src/contracts/authorize.ts
+++ b/chaincode/src/contracts/authorize.ts
@@ -102,7 +102,10 @@ export async function authorize(ctx: GalaChainContext, options: AuthorizeOptions
 
   if (quorum) {
     const user = ctx.callingUserProfile;
-    const requiredSignatures = Math.max(user.requiredSignatures, options.quorum ?? 1);
+    const requiredSignatures = Math.max(
+      user.requiredSignatures ?? 1,
+      options.quorum ?? 1
+    );
     if (quorum.signedByKeys.length < requiredSignatures) {
       throw new UnauthorizedError(
         `Insufficient signatures: got ${quorum.signedByKeys.length}, required ${requiredSignatures}.`,


### PR DESCRIPTION
## Summary
- default profile pubKeyCount and requiredSignatures when authenticating
- guard against missing pubKeyCount when building quorum info
- default required signatures during authorization

## Testing
- `npx nx lint chaincode` *(fails: 78 problems (15 errors, 63 warnings))*
- `CI=1 npx nx test chaincode` *(fails: should load legacy public key format, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e48e71788330b201ae5c45ac1507