### PR TITLE
fix: restore signer public key check

### DIFF
--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -313,7 +313,9 @@ export class ChainCallDTO {
     }
 
     if (this.signing !== SigningScheme.TON) {
-      this.signerPublicKey = signatures.getPublicKey(privateKey);
+      if (this.signerPublicKey === undefined && this.signerAddress === undefined) {
+        this.signerPublicKey = signatures.getPublicKey(privateKey);
+      }
     }
 
     const payload = {


### PR DESCRIPTION
## Summary
- only derive signer public key when both signerPublicKey and signerAddress are missing

## Testing
- `npx jest chain-api/src/types/dtos.spec.ts --runInBand` (fails: Jest failed to parse TypeScript config `getJestProjects`)


------
https://chatgpt.com/codex/tasks/task_e_68c31e292224833096a228dd35b4d517