### PR TITLE
fix signing public key guard

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -136,6 +136,24 @@ describe("ChainCallDTO", () => {
     expect(dto.isSignatureValid(publicKey)).toEqual(true);
   });
 
+  it("should update signerPublicKey for each signature", () => {
+    const kp1 = genKeyPair();
+    const kp2 = genKeyPair();
+    const dto = new TestDto();
+    dto.amounts = [new BigNumber("12.3")];
+
+    const pk1 = signatures.getPublicKey(kp1.privateKey);
+    const pk2 = signatures.getPublicKey(kp2.privateKey);
+
+    dto.sign(kp1.privateKey);
+    dto.sign(kp2.privateKey);
+
+    expect(dto.signatures).toHaveLength(2);
+    expect(dto.signatures?.[0].signerPublicKey).toEqual(pk1);
+    expect(dto.signatures?.[1].signerPublicKey).toEqual(pk2);
+    expect(dto.signerPublicKey).toEqual(pk2);
+  });
+
   it("should sign and verify signature (edge case - shorter private key with missing trailing 0)", () => {
     // Given
     const privateKey = "e8d506db1e7c8d98dbc6752537939312702962f48e169084a7babbb5c96217f";

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -312,8 +312,14 @@ export class ChainCallDTO {
       }
     }
 
-    if (this.signing !== SigningScheme.TON) {
-      if (this.signerPublicKey === undefined && this.signerAddress === undefined) {
+    if (this.signing !== SigningScheme.TON && this.signerAddress === undefined) {
+      if (this.signatures?.length) {
+        const lastPublicKey = this.signatures[this.signatures.length - 1]?.signerPublicKey;
+        if (this.signerPublicKey === lastPublicKey || lastPublicKey === undefined) {
+          this.signerPublicKey = undefined;
+        }
+      }
+      if (this.signerPublicKey === undefined) {
         this.signerPublicKey = signatures.getPublicKey(privateKey);
       }
     }

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -313,7 +313,9 @@ export class ChainCallDTO {
     }
 
     if (this.signing !== SigningScheme.TON) {
-      this.signerPublicKey = signatures.getPublicKey(privateKey);
+      if (this.signerPublicKey === undefined && this.signerAddress === undefined) {
+        this.signerPublicKey = signatures.getPublicKey(privateKey);
+      }
     }
 
     const payload = {


### PR DESCRIPTION
## Summary
- only derive signer public key automatically when neither signer key nor address provided in ChainCallDTO.sign

## Testing
- `npx nx test chain-api`

------
https://chatgpt.com/codex/tasks/task_e_68c31e292224833096a228dd35b4d517