### PR TITLE
fix: preserve metadata of first signature

### DIFF
--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -290,6 +290,16 @@ export class ChainCallDTO {
   }
 
   public sign(privateKey: string, useDer = false): void {
+    if (!this._originalSignature && this.signature) {
+      const existing = new SignatureDto();
+      existing.signature = this.signature;
+      existing.prefix = this.prefix;
+      existing.signerAddress = this.signerAddress;
+      existing.signerPublicKey = this.signerPublicKey;
+      existing.signing = this.signing;
+      this._originalSignature = instanceToInstance(existing);
+    }
+
     const sdto = new SignatureDto();
     sdto.signerPublicKey = this.signerPublicKey;
     sdto.signerAddress = this.signerAddress;

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Type, instanceToInstance, plainToInstance } from "class-transformer";
+import { Exclude, Type, instanceToInstance, plainToInstance } from "class-transformer";
 import {
   ArrayMaxSize,
   ArrayMinSize,
@@ -229,6 +229,9 @@ export class ChainCallDTO {
   @Type(() => SignatureDto)
   public signatures?: SignatureDto[];
 
+  @Exclude()
+  private _originalSignature?: SignatureDto;
+
   @JSONSchema({
     description: "Unit timestamp when the DTO expires. If the timestamp is in the past, the DTO is not valid."
   })
@@ -317,15 +320,22 @@ export class ChainCallDTO {
       this.signerAddress = sdto.signerAddress;
       this.prefix = sdto.prefix;
       this.signing = sdto.signing;
+      this._originalSignature = instanceToInstance(sdto);
     } else {
       if (!this.signatures) {
-        const existing = new SignatureDto();
-        existing.signature = this.signature!;
-        existing.prefix = this.prefix;
-        existing.signerAddress = this.signerAddress;
-        existing.signerPublicKey = this.signerPublicKey;
-        existing.signing = this.signing;
+        let existing: SignatureDto;
+        if (this._originalSignature) {
+          existing = this._originalSignature;
+        } else {
+          existing = new SignatureDto();
+          existing.signature = this.signature!;
+          existing.prefix = this.prefix;
+          existing.signerAddress = this.signerAddress;
+          existing.signerPublicKey = this.signerPublicKey;
+          existing.signing = this.signing;
+        }
         this.signatures = [existing];
+        this._originalSignature = undefined;
         this.signature = undefined;
         this.signerPublicKey = undefined;
         this.signerAddress = undefined;


### PR DESCRIPTION
## Summary
- keep snapshot of first signature metadata before subsequent `sign` calls
- reuse stored metadata when promoting single signature to signatures array

## Testing
- `npx nx test chain-api`
- `npx eslint chain-api/src/types/dtos.ts chain-api/src/types/dtos.spec.ts chain-api/src/utils/signatures/getPayloadToSign.ts chain-api/src/utils/generate-schema.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c336a24afc8330bf79ef1925ba6e58