### PR TITLE
fix: preserve metadata of first signature

### DIFF
--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -290,6 +290,16 @@ export class ChainCallDTO {
   }
 
   public sign(privateKey: string, useDer = false): void {
+    if (!this._originalSignature && this.signature) {
+      const existing = new SignatureDto();
+      existing.signature = this.signature;
+      existing.prefix = this.prefix;
+      existing.signerAddress = this.signerAddress;
+      existing.signerPublicKey = this.signerPublicKey;
+      existing.signing = this.signing;
+      this._originalSignature = instanceToInstance(existing);
+    }
+
     const sdto = new SignatureDto();
     sdto.signerPublicKey = this.signerPublicKey;
     sdto.signerAddress = this.signerAddress;


### PR DESCRIPTION
## Summary
- capture existing signature metadata at `sign` start to keep original signer when adding cosignatures

## Testing
- `npx nx test chain-api`
- `npx eslint chain-api/src/types/dtos.ts chain-api/src/types/dtos.spec.ts chain-api/src/utils/signatures/getPayloadToSign.ts chain-api/src/utils/generate-schema.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c3403a6bb08330980e3e724c0cd0cd