### PR TITLE
refactor: avoid redundant signer public key

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -150,7 +150,8 @@ describe("ChainCallDTO", () => {
 
     // Then
     expect(dto.signature).toEqual(expect.stringMatching(/.{50,}/));
-    expect(dto.isSignatureValid(dto.signerPublicKey ?? "")).toEqual(true);
+    const publicKey = signatures.getPublicKey(privateKey);
+    expect(dto.isSignatureValid(publicKey)).toEqual(true);
   });
 
   it("should sign and fail to verify signature (invalid key)", () => {
@@ -229,7 +230,7 @@ describe("ChainCallDTO", () => {
 
     const signature = {
       signature: dto.signature ?? "",
-      signerPublicKey: dto.signerPublicKey,
+      signerPublicKey: signatures.getPublicKey(privateKey),
       signerAddress: dto.signerAddress,
       signing: dto.signing,
       prefix: dto.prefix

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -312,9 +312,8 @@ export class ChainCallDTO {
       }
     }
 
-    if (this.signing !== SigningScheme.TON) {
-      this.signerPublicKey = signatures.getPublicKey(privateKey);
-    }
+    const signerPublicKey =
+      this.signing !== SigningScheme.TON ? signatures.getPublicKey(privateKey) : undefined;
 
     const payload = {
       ...this,
@@ -337,7 +336,7 @@ export class ChainCallDTO {
 
     const signatureDto: SignatureDto = {
       signature: this.signature,
-      signerPublicKey: this.signerPublicKey,
+      signerPublicKey,
       signerAddress: this.signerAddress,
       signing: this.signing,
       prefix: this.prefix


### PR DESCRIPTION
## Summary
- avoid storing signerPublicKey on DTO during signing
- update tests to derive public key directly

## Testing
- `npx nx lint chain-api`
- `npx nx test chain-api`


------
https://chatgpt.com/codex/tasks/task_e_68c344c5ae4c8330bd96a7b7b4fa321c