### PR TITLE
feat: simplify signature validation

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -165,11 +165,8 @@ describe("ChainCallDTO", () => {
     dto.sign(privateKey);
 
     // Then
-    const signature = dto.signature;
-    expect(signature).toBeDefined();
-    if (signature) {
-      expect(dto.isSignatureValid(signature, invalid.publicKey)).toEqual(false);
-    }
+    expect(dto.signature).toBeDefined();
+    expect(dto.isSignatureValid(invalid.publicKey)).toEqual(false);
   });
 
   it("should sign and fail to verify signature (invalid payload)", () => {
@@ -184,11 +181,8 @@ describe("ChainCallDTO", () => {
     dto.key = "i-will-break-this";
 
     // Then
-    const signature = dto.signature;
-    expect(signature).toBeDefined();
-    if (signature) {
-      expect(dto.isSignatureValid(signature, publicKey)).toEqual(false);
-    }
+    expect(dto.signature).toBeDefined();
+    expect(dto.isSignatureValid(publicKey)).toEqual(false);
   });
 
   it("should sign and verify TON signature", async () => {
@@ -228,18 +222,25 @@ describe("ChainCallDTO", () => {
 
     dto.sign(privateKey);
 
-    const signature = {
-      signature: dto.signature ?? "",
-      signerPublicKey: signatures.getPublicKey(privateKey),
-      signerAddress: dto.signerAddress,
-      signing: dto.signing,
-      prefix: dto.prefix
-    };
+    const publicKey = signatures.getPublicKey(privateKey);
 
     dto.signing = SigningScheme.TON;
     dto.prefix = "bar";
 
-    expect(dto.isSignatureValid(signature)).toEqual(true);
+    expect(dto.isSignatureValid(publicKey)).toEqual(true);
+  });
+
+  it("should validate signature by index", () => {
+    const first = genKeyPair();
+    const second = genKeyPair();
+    const dto = new TestDto();
+    dto.amounts = [new BigNumber("5")];
+
+    dto.sign(first.privateKey);
+    dto.sign(second.privateKey);
+
+    expect(dto.isSignatureValid(first.publicKey, 0)).toEqual(true);
+    expect(dto.isSignatureValid(second.publicKey, 1)).toEqual(true);
   });
 
   it("should convert legacy single signature", () => {

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -354,32 +354,16 @@ export class ChainCallDTO {
     return copied;
   }
 
-  public isSignatureValid(signatureOrPublicKey: string | SignatureDto, publicKey?: string): boolean {
-    let signature: string;
-    let pk: string | undefined;
-    let signing: SigningScheme | undefined;
-    let prefix = this.prefix;
-    let payloadSigning: SigningScheme | undefined;
-
-    if (typeof signatureOrPublicKey === "object") {
-      signature = signatureOrPublicKey.signature ?? "";
-      pk = signatureOrPublicKey.signerPublicKey ?? publicKey;
-      signing = signatureOrPublicKey.signing;
-      payloadSigning = signatureOrPublicKey.signing;
-      prefix = signatureOrPublicKey.prefix ?? prefix;
-    } else if (publicKey) {
-      signature = signatureOrPublicKey;
-      pk = publicKey;
-      signing = this.signing;
-      payloadSigning = this.signing;
-    } else {
-      signature = this.signature ?? "";
-      pk = signatureOrPublicKey;
-      signing = this.signing;
-      payloadSigning = this.signing;
+  public isSignatureValid(publicKey: string, index = 0): boolean {
+    const signatureObj: ChainCallDTO | SignatureDto | undefined =
+      this.signatures?.[index] ?? (index === 0 ? this : undefined);
+    if (!signatureObj) {
+      throw new ValidationFailedError(`No signature at index ${index}`);
     }
 
-    signing = signing ?? SigningScheme.ETH;
+    const signing = signatureObj.signing ?? SigningScheme.ETH;
+    const signature = signatureObj.signature ?? "";
+    const prefix = signatureObj.prefix ?? this.prefix;
 
     const payload = {
       ...this,
@@ -388,16 +372,15 @@ export class ChainCallDTO {
       signerPublicKey: undefined,
       signerAddress: undefined,
       prefix: undefined,
-      signing: payloadSigning
+      signing: signatureObj.signing
     };
 
     if (signing === SigningScheme.TON) {
-      const signatureBuff = Buffer.from(signature ?? "", "base64");
-      const publicKeyBuff = Buffer.from(pk ?? "", "base64");
+      const signatureBuff = Buffer.from(signature, "base64");
+      const publicKeyBuff = Buffer.from(publicKey, "base64");
       return signatures.ton.isValidSignature(signatureBuff, payload, publicKeyBuff, prefix);
-    } else {
-      return signatures.isValid(signature ?? "", payload, pk ?? "");
     }
+    return signatures.isValid(signature, payload, publicKey);
   }
 }
 

--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -180,12 +180,13 @@ export async function authenticateSingle(
       (k) => PublicKeyService.getUserAddress(k, scheme) === sig.signerAddress
     );
 
+    const index = dto.signatures?.indexOf(sig) ?? 0;
     if (key) {
-      if (!dto.isSignatureValid(sig, key)) {
+      if (!dto.isSignatureValid(key, index)) {
         throw new PkInvalidSignatureError(profile.alias);
       }
     } else {
-      key = keys.find((k) => dto.isSignatureValid(sig, k));
+      key = keys.find((k) => dto.isSignatureValid(k, index));
       if (!key) {
         throw new PkInvalidSignatureError(profile.alias);
       }
@@ -195,7 +196,8 @@ export async function authenticateSingle(
       scheme === SigningScheme.TON ? key : signatures.getNonCompactHexPublicKey(key);
     return { profile, signedByKey: keyHex };
   } else if (sig.signerPublicKey !== undefined) {
-    if (!dto.isSignatureValid(sig)) {
+    const index = dto.signatures?.indexOf(sig) ?? 0;
+    if (!dto.isSignatureValid(sig.signerPublicKey, index)) {
       const address = PublicKeyService.getUserAddress(sig.signerPublicKey, signing);
       throw new PkInvalidSignatureError(address);
     }


### PR DESCRIPTION
## Summary
- simplify `isSignatureValid` to accept a public key and optional signature index
- adjust authentication flow to use indexed signature validation
- update and extend tests for signature verification

## Testing
- `./node_modules/.bin/nx test chain-api` *(fails: /usr/bin/env: 'node': No such file or directory)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_e_68c347d6444883309f9f0b45253b1dd9