### PR TITLE
feat: support single or multiple public keys

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -19,7 +19,7 @@ import { ec as EC } from "elliptic";
 
 import { SigningScheme, ValidationFailedError, getValidationErrorMessages, signatures } from "../utils";
 import { BigNumberArrayProperty, BigNumberProperty } from "../validators";
-import { ChainCallDTO, ClassConstructor, convertLegacySignatures } from "./dtos";
+import { ChainCallDTO, ClassConstructor, convertLegacySignatures, convertLegacyPublicKeys } from "./dtos";
 
 const getInstanceOrErrorInfo = async <T extends ChainCallDTO>(
   constructor: ClassConstructor<T>,
@@ -258,5 +258,13 @@ describe("ChainCallDTO", () => {
         prefix: undefined
       }
     ]);
+  });
+});
+
+describe("convertLegacyPublicKeys", () => {
+  it("should convert legacy single public key", () => {
+    const dto: { publicKey?: string; publicKeys?: string[] } = { publicKey: "pk" };
+    convertLegacyPublicKeys(dto);
+    expect(dto.publicKeys).toEqual(["pk"]);
   });
 });

--- a/chain-api/src/types/dtos.ts
+++ b/chain-api/src/types/dtos.ts
@@ -19,6 +19,7 @@ import {
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  ValidateIf,
   Max,
   Min,
   ValidateNested,
@@ -416,6 +417,13 @@ export function convertLegacySignatures<T extends ChainCallDTO>(dto: T): T {
   return dto;
 }
 
+export function convertLegacyPublicKeys<T extends { publicKey?: string; publicKeys?: string[] }>(dto: T): T {
+  if (!dto.publicKeys && dto.publicKey) {
+    dto.publicKeys = [dto.publicKey];
+  }
+  return dto;
+}
+
 // It just makes uniqueKey required
 export class SubmitCallDTO extends ChainCallDTO {
   @IsNotEmpty()
@@ -618,10 +626,16 @@ export class RegisterUserDto extends SubmitCallDTO {
   /**
    * @description Public secp256k1 keys (compact or non-compact, hex or base64).
    */
+  @JSONSchema({ description: "Public secp256k1 key (compact or non-compact, hex or base64)." })
+  @ValidateIf((o) => !o.publicKeys || o.publicKeys.length === 0)
+  @IsNotEmpty()
+  publicKey?: string;
+
   @JSONSchema({ description: "Public secp256k1 keys (compact or non-compact, hex or base64)." })
+  @ValidateIf((o) => !o.publicKey)
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
-  publicKeys: string[];
+  publicKeys?: string[];
 }
 
 /**
@@ -634,10 +648,16 @@ export class RegisterUserDto extends SubmitCallDTO {
   description: `Dto for secure method to save public keys for Eth users. Method is called and signed by Curators`
 })
 export class RegisterEthUserDto extends SubmitCallDTO {
+  @JSONSchema({ description: "Public secp256k1 key (compact or non-compact, hex or base64)." })
+  @ValidateIf((o) => !o.publicKeys || o.publicKeys.length === 0)
+  @IsNotEmpty()
+  publicKey?: string;
+
   @JSONSchema({ description: "Public secp256k1 keys (compact or non-compact, hex or base64)." })
+  @ValidateIf((o) => !o.publicKey)
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
-  publicKeys: string[];
+  publicKeys?: string[];
 }
 
 /**
@@ -650,10 +670,16 @@ export class RegisterEthUserDto extends SubmitCallDTO {
   description: `Dto for secure method to save public keys for TON users. Method is called and signed by Curators`
 })
 export class RegisterTonUserDto extends SubmitCallDTO {
+  @JSONSchema({ description: "TON user public key (Ed25519 in base64)." })
+  @ValidateIf((o) => !o.publicKeys || o.publicKeys.length === 0)
+  @IsNotEmpty()
+  publicKey?: string;
+
   @JSONSchema({ description: "TON user public keys (Ed25519 in base64)." })
+  @ValidateIf((o) => !o.publicKey)
   @IsNotEmpty({ each: true })
   @ArrayMinSize(1)
-  publicKeys: string[];
+  publicKeys?: string[];
 }
 
 export class UpdatePublicKeyDto extends SubmitCallDTO {

--- a/chaincode/src/contracts/PublicKeyContract.ts
+++ b/chaincode/src/contracts/PublicKeyContract.ts
@@ -21,6 +21,7 @@ import {
   RegisterTonUserDto,
   RegisterUserDto,
   SigningScheme,
+  convertLegacyPublicKeys,
   UpdatePublicKeyDto,
   UpdateUserRolesDto,
   UserAlias,
@@ -81,16 +82,17 @@ export class PublicKeyContract extends GalaContract {
     ...requireRegistrarAuth
   })
   public async RegisterUser(ctx: GalaChainContext, dto: RegisterUserDto): Promise<string> {
-    if (!dto.user.startsWith("client|")) {
-      const message = `User alias should start with 'client|', but got: ${dto.user}`;
+    const dtoWithKeys = convertLegacyPublicKeys(dto);
+    if (!dtoWithKeys.user.startsWith("client|")) {
+      const message = `User alias should start with 'client|', but got: ${dtoWithKeys.user}`;
       throw new ValidationFailedError(message);
     }
-    PublicKeyContract.ensurePublicKeys(dto.publicKeys);
+    PublicKeyContract.ensurePublicKeys(dtoWithKeys.publicKeys);
 
-    const userAlias = dto.user;
-    const signing = dto.signing ?? SigningScheme.ETH;
+    const userAlias = dtoWithKeys.user;
+    const signing = dtoWithKeys.signing ?? SigningScheme.ETH;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, signing);
+    return PublicKeyService.registerUser(ctx, dtoWithKeys.publicKeys, userAlias, signing);
   }
 
   @Submit({
@@ -100,11 +102,12 @@ export class PublicKeyContract extends GalaContract {
     ...requireRegistrarAuth
   })
   public async RegisterEthUser(ctx: GalaChainContext, dto: RegisterEthUserDto): Promise<string> {
-    PublicKeyContract.ensurePublicKeys(dto.publicKeys);
-    const ethAddress = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.ETH);
+    const dtoWithKeys = convertLegacyPublicKeys(dto);
+    PublicKeyContract.ensurePublicKeys(dtoWithKeys.publicKeys);
+    const ethAddress = PublicKeyService.getUserAddress(dtoWithKeys.publicKeys[0], SigningScheme.ETH);
     const userAlias = `eth|${ethAddress}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.ETH);
+    return PublicKeyService.registerUser(ctx, dtoWithKeys.publicKeys, userAlias, SigningScheme.ETH);
   }
 
   @Submit({
@@ -114,11 +117,12 @@ export class PublicKeyContract extends GalaContract {
     ...requireRegistrarAuth
   })
   public async RegisterTonUser(ctx: GalaChainContext, dto: RegisterTonUserDto): Promise<string> {
-    PublicKeyContract.ensurePublicKeys(dto.publicKeys);
-    const address = PublicKeyService.getUserAddress(dto.publicKeys[0], SigningScheme.TON);
+    const dtoWithKeys = convertLegacyPublicKeys(dto);
+    PublicKeyContract.ensurePublicKeys(dtoWithKeys.publicKeys);
+    const address = PublicKeyService.getUserAddress(dtoWithKeys.publicKeys[0], SigningScheme.TON);
     const userAlias = `ton|${address}` as UserAlias;
 
-    return PublicKeyService.registerUser(ctx, dto.publicKeys, userAlias, SigningScheme.TON);
+    return PublicKeyService.registerUser(ctx, dtoWithKeys.publicKeys, userAlias, SigningScheme.TON);
   }
 
   @Submit({


### PR DESCRIPTION
## Summary
- allow DTOs to accept either `publicKey` or `publicKeys`
- normalize legacy single `publicKey` values
- handle public key normalization in PublicKeyContract

## Testing
- `npx nx test chain-api`
- `npx nx test chaincode` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68c43611e2c083309bc50d6be82087e5