### PR TITLE
style: tidy PublicKeyContract tests

### DIFF
--- a/chaincode/src/contracts/PublicKeyContract.spec.ts
+++ b/chaincode/src/contracts/PublicKeyContract.spec.ts
@@ -177,7 +177,7 @@ describe("RegisterUser", () => {
     chaincode.setCallingUser(user2.alias);
     const dto = await createValidSubmitDTO<RegisterUserDto>(RegisterUserDto, {
       user: user2.alias,
-      publicKeys: [user2.publicKey],
+      publicKeys: [user2.publicKey]
     });
 
     const response = await chaincode.invoke("PublicKeyContract:SavePublicKey", dto);
@@ -223,7 +223,7 @@ describe("RegisterUser", () => {
     const dto = await createValidSubmitDTO<RegisterUserDto>(RegisterUserDto, {
       user: user2.alias,
       publicKeys: [user2.publicKey],
-      signing: SigningScheme.ETH,
+      signing: SigningScheme.ETH
     });
 
     const response = await chaincode.invoke(
@@ -531,15 +531,8 @@ describe("UpdatePublicKey", () => {
     signedEthToTon.signing = SigningScheme.ETH;
 
     // When
-    const responseTonToEth = await chaincode.invoke(
-      "PublicKeyContract:UpdatePublicKey",
-      signedTonToEth
-    );
-
-    const responseEthToTon = await chaincode.invoke(
-      "PublicKeyContract:UpdatePublicKey",
-      signedEthToTon
-    );
+    const responseTonToEth = await chaincode.invoke("PublicKeyContract:UpdatePublicKey", signedTonToEth);
+    const responseEthToTon = await chaincode.invoke("PublicKeyContract:UpdatePublicKey", signedEthToTon);
 
     // Then
     expect(responseTonToEth).toEqual(transactionErrorMessageContains("Invalid public key length"));


### PR DESCRIPTION
## Summary
- remove stray trailing commas
- inline chaincode.invoke calls for readability

## Testing
- `npx nx run chaincode:lint --files chaincode/src/contracts/PublicKeyContract.spec.ts` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68c83b3d75a88330912a7ef48b7adb62