### PR TITLE
Simplify quorum signature calculation

### DIFF
--- a/chaincode/src/contracts/authorize.ts
+++ b/chaincode/src/contracts/authorize.ts
@@ -102,10 +102,7 @@ export async function authorize(ctx: GalaChainContext, options: AuthorizeOptions
 
   if (quorum) {
     const user = ctx.callingUserProfile;
-    const requiredSignatures = Math.max(
-      user.requiredSignatures ?? 1,
-      options.quorum ?? 1
-    );
+    const requiredSignatures = Math.max(user.requiredSignatures ?? 1, options.quorum ?? 1);
     if (quorum.signedByKeys.length < requiredSignatures) {
       throw new UnauthorizedError(
         `Insufficient signatures: got ${quorum.signedByKeys.length}, required ${requiredSignatures}.`,


### PR DESCRIPTION
## Summary
- simplify required signature calculation in the authorize contract by using a single-line Math.max expression

## Testing
- npx nx run chaincode:lint --files chaincode/src/contracts/authorize.ts *(fails: existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68c85769efa483309b20905c6b747850