### PR TITLE
Refine default required signatures assignment

### DIFF
--- a/chaincode/src/types/GalaChainContext.ts
+++ b/chaincode/src/types/GalaChainContext.ts
@@ -130,8 +130,8 @@ export class GalaChainContext extends Context {
     this.callingUserValue = d.alias;
     this.callingUserRolesValue = d.roles ?? [UserRole.EVALUATE]; // default if `roles` is undefined
     this.callingUserPubKeyCountValue = d.pubKeyCount ?? 1;
-    this.callingUserRequiredSignaturesValue =
-      d.requiredSignatures ?? Math.floor(this.callingUserPubKeyCountValue / 2) + 1;
+    const defaultRequiredSignatures = Math.floor(this.callingUserPubKeyCountValue / 2) + 1;
+    this.callingUserRequiredSignaturesValue = d.requiredSignatures ?? defaultRequiredSignatures;
 
     if (d.ethAddress !== undefined) {
       this.callingUserEthAddressValue = d.ethAddress;


### PR DESCRIPTION
## Summary
- keep the callingUserRequiredSignaturesValue assignment on one line by storing the default in a local constant

## Testing
- npx nx run chaincode:lint --files chaincode/src/types/GalaChainContext.ts --output-style stream

------
https://chatgpt.com/codex/tasks/task_e_68c85bfdb520833080ac55df60611538