### PR TITLE
chore: strengthen typing for lint compliance

### DIFF
--- a/chain-cli/src/commands/logs/index.ts
+++ b/chain-cli/src/commands/logs/index.ts
@@ -129,8 +129,9 @@ export default class Log extends BaseCommand<typeof Log> {
       for (const logEntry of logs) {
         this.printLog(logEntry);
       }
-    } catch (error: any) {
-      throw new FetchLogsError(error.message);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new FetchLogsError(message);
     }
   }
 
@@ -147,8 +148,9 @@ export default class Log extends BaseCommand<typeof Log> {
           this.handleSSEEvent(eventBlock);
         });
       });
-    } catch (error: any) {
-      throw new FetchLogsError(error.message);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new FetchLogsError(message);
     }
   }
 
@@ -261,7 +263,7 @@ export default class Log extends BaseCommand<typeof Log> {
     );
   }
 
-  handleError(error: any): void {
+  handleError(error: unknown): void {
     if (error instanceof UnauthorizedError) {
       this.error(chalk.red(`Unauthorized: ${error.message}`), { exit: 1 });
     } else if (error instanceof BadRequestError) {
@@ -269,7 +271,8 @@ export default class Log extends BaseCommand<typeof Log> {
     } else if (error instanceof FetchLogsError) {
       this.error(chalk.red(`Failed to fetch logs: ${error.message}`), { exit: 1 });
     } else {
-      this.error(chalk.red(`An unexpected error occurred: ${error.message}`), { exit: 1 });
+      const message = error instanceof Error ? error.message : String(error);
+      this.error(chalk.red(`An unexpected error occurred: ${message}`), { exit: 1 });
     }
   }
 }

--- a/chain-connect/src/ClientApi.spec.ts
+++ b/chain-connect/src/ClientApi.spec.ts
@@ -32,8 +32,12 @@ import { BrowserConnectClient } from "./customClients";
 // https://privatekeys.pw/key/1d3cc061492016bcd5e7ea2c31b1cf3dec584e07a38e21df7ef3049c6b224e70#addresses
 const sampleAddr = "0x3bb75c2Da3B669E253C338101420CC8dEBf0a777";
 
+type JsonRpcParams = unknown[] | Record<string, unknown>;
+type JsonRpcResult = string | string[];
+
 class EthereumMock extends EventEmitter {
-  send(method: string, params?: Array<any> | Record<string, any>): Promise<any> {
+  send(method: string, params?: JsonRpcParams): Promise<JsonRpcResult> {
+    void params;
     if (method === "eth_requestAccounts") {
       return Promise.resolve([sampleAddr]);
     } else if (method === "eth_accounts") {
@@ -44,7 +48,7 @@ class EthereumMock extends EventEmitter {
       throw new Error(`Method not mocked: ${method}`);
     }
   }
-  request(request: { method: string; params?: Array<any> | Record<string, any> }): Promise<any> {
+  request(request: { method: string; params?: JsonRpcParams }): Promise<JsonRpcResult> {
     if (request.method === "eth_requestAccounts") {
       return Promise.resolve([sampleAddr]);
     } else if (request.method === "eth_accounts") {

--- a/chain-connect/src/GalaChainClient.spec.ts
+++ b/chain-connect/src/GalaChainClient.spec.ts
@@ -33,8 +33,12 @@ import { generateEIP712Types } from "./utils";
 // https://privatekeys.pw/key/1d3cc061492016bcd5e7ea2c31b1cf3dec584e07a38e21df7ef3049c6b224e70#addresses
 const sampleAddr = "0x3bb75c2Da3B669E253C338101420CC8dEBf0a777";
 
+type JsonRpcParams = unknown[] | Record<string, unknown>;
+type JsonRpcResult = string | string[];
+
 class EthereumMock extends EventEmitter {
-  send(method: string, params?: Array<any> | Record<string, any>): Promise<any> {
+  send(method: string, params?: JsonRpcParams): Promise<JsonRpcResult> {
+    void params;
     if (method === "eth_requestAccounts") {
       return Promise.resolve([sampleAddr]);
     } else if (method === "eth_accounts") {
@@ -45,7 +49,7 @@ class EthereumMock extends EventEmitter {
       throw new Error(`Method not mocked: ${method}`);
     }
   }
-  request(request: { method: string; params?: Array<any> | Record<string, any> }): Promise<any> {
+  request(request: { method: string; params?: JsonRpcParams }): Promise<JsonRpcResult> {
     if (request.method === "eth_requestAccounts") {
       return Promise.resolve([sampleAddr]);
     } else if (request.method === "eth_accounts") {
@@ -220,8 +224,7 @@ describe("BrowserConnectClient", () => {
       console.log("Accounts changed:", accounts);
     });
     // Trigger the accountsChanged event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window.ethereum as any).emit("accountsChanged", accounts);
+    (window.ethereum as unknown as EventEmitter).emit("accountsChanged", accounts);
 
     expect(consoleSpy).toHaveBeenCalledWith("Accounts changed:", accounts);
     consoleSpy.mockRestore();
@@ -365,8 +368,7 @@ describe("BrowserConnectClient", () => {
     await client.connect();
     await client.connect();
     // Trigger the accountsChanged event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window.ethereum as any).emit("accountsChanged", [sampleAddr]);
+    (window.ethereum as unknown as EventEmitter).emit("accountsChanged", [sampleAddr]);
     // the client should emit two events (accountChanged and accountsChanged)
     // for each window.ethereum accountsChanged event
     expect(spy).toHaveBeenCalledTimes(2);
@@ -378,8 +380,7 @@ describe("BrowserConnectClient", () => {
     await client.connect();
     client.disconnect();
     // Trigger the accountsChanged event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window.ethereum as any).emit("accountsChanged", [sampleAddr]);
+    (window.ethereum as unknown as EventEmitter).emit("accountsChanged", [sampleAddr]);
     expect(spy).toHaveBeenCalledTimes(0);
   });
 
@@ -397,8 +398,7 @@ describe("BrowserConnectClient", () => {
     client.disconnect();
     await client.connect();
     // Trigger the accountsChanged event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window.ethereum as any).emit("accountsChanged", [sampleAddr]);
+    (window.ethereum as unknown as EventEmitter).emit("accountsChanged", [sampleAddr]);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -138,11 +138,11 @@ export class BrowserConnectClient extends WebSigner {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
-      delete (basePayload as any).signature;
-      delete (basePayload as any).signatures;
-      delete (basePayload as any).signerAddress;
-      delete (basePayload as any).signerPublicKey;
-      delete (basePayload as any).prefix;
+      delete basePayload.signature;
+      delete basePayload.signatures;
+      delete basePayload.signerAddress;
+      delete basePayload.signerPublicKey;
+      delete basePayload.prefix;
 
       const domain = { name: "GalaChain" };
       const types = generateEIP712Types(method, basePayload);
@@ -172,8 +172,9 @@ export class BrowserConnectClient extends WebSigner {
         signerPublicKey = undefined;
       }
 
-      const existing = Array.isArray((payload as any).signatures)
-        ? ((payload as any).signatures as SignatureDto[])
+      const payloadRecord = payload as Record<string, unknown>;
+      const existing = Array.isArray(payloadRecord.signatures)
+        ? (payloadRecord.signatures as SignatureDto[])
         : [];
 
       const signatureDto: SignatureDto = {

--- a/chain-connect/src/customClients/SigningClient.ts
+++ b/chain-connect/src/customClients/SigningClient.ts
@@ -53,11 +53,11 @@ export class SigningClient extends CustomClient {
       const basePayload = { ...payload } as Record<string, unknown>;
       delete basePayload.types;
       delete basePayload.domain;
-      delete (basePayload as any).signature;
-      delete (basePayload as any).signatures;
-      delete (basePayload as any).signerAddress;
-      delete (basePayload as any).signerPublicKey;
-      delete (basePayload as any).prefix;
+      delete basePayload.signature;
+      delete basePayload.signatures;
+      delete basePayload.signerAddress;
+      delete basePayload.signerPublicKey;
+      delete basePayload.prefix;
 
       const prefix = calculatePersonalSignPrefix(basePayload);
       const prefixedPayload = { ...basePayload, prefix };
@@ -77,8 +77,9 @@ export class SigningClient extends CustomClient {
         throw new Error("Unsupported signing type");
       }
 
-      const existing = Array.isArray((payload as any).signatures)
-        ? ((payload as any).signatures as SignatureDto[])
+      const payloadRecord = payload as Record<string, unknown>;
+      const existing = Array.isArray(payloadRecord.signatures)
+        ? (payloadRecord.signatures as SignatureDto[])
         : [];
 
       const signatureDto: SignatureDto = {

--- a/chain-connect/src/helpers.ts
+++ b/chain-connect/src/helpers.ts
@@ -46,7 +46,7 @@ export interface ExtendedEip1193Provider extends Eip1193Provider {
   /** Removes a listener for account change events */
   removeListener(event: "accountsChanged", handler: Listener<string[]>): void;
   /** Array of available providers (for multi-wallet scenarios) */
-  providers?: Array<any>;
+  providers?: Eip1193Provider[];
   /** Flag indicating if this is a Trust Wallet provider */
   isTrust?: boolean;
 }
@@ -71,8 +71,7 @@ export type Listener<T> = (data: T) => void;
  * Simple event emitter implementation for handling wallet events.
  * @template Events - Record type defining available events and their data types
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class EventEmitter<Events extends Record<string, any>> {
+export class EventEmitter<Events extends Record<string, unknown>> {
   private listeners: { [K in keyof Events]?: Listener<Events[K]>[] } = {};
 
   /**


### PR DESCRIPTION
## Summary
- harden log retrieval error handling to avoid `any` usage
- tighten network-up flag validation typing and mapping helpers
- replace loose chain-connect typings with specific guards and payload handling

## Testing
- NX_DAEMON=false npx nx run @sdk/source:lint --files chain-cli/src/commands/logs/index.ts,chain-cli/src/commands/network-up/index.ts,chain-cli/src/galachain-utils.ts,chain-connect/src/ClientApi.spec.ts,chain-connect/src/GalaChainClient.spec.ts,chain-connect/src/GalaChainClient.ts,chain-connect/src/customClients/BrowserConnectClient.ts,chain-connect/src/customClients/SigningClient.ts,chain-connect/src/helpers.ts --output-style=static

------
https://chatgpt.com/codex/tasks/task_e_68c85d5b6ecc8330b0b3f45a3d59c92d