### PR TITLE
chore: clean up unused variables in chaincode fees

### DIFF
--- a/chaincode/src/fees/exitGateImplementations.ts
+++ b/chaincode/src/fees/exitGateImplementations.ts
@@ -47,7 +47,7 @@ export interface IMintPostProcessing {
 }
 
 export async function mintPostProcessing(ctx: GalaChainContext, data: IMintPostProcessing) {
-  const { tokenClass, tokens, owner, quantity, feeCode } = data;
+  const { tokenClass, owner } = data;
   const { collection, category, type, additionalKey } = tokenClass;
 
   const mintConfiguration: TokenMintConfiguration | undefined = await getObjectByKey(
@@ -115,7 +115,7 @@ export async function lockOnMintProcessing(ctx: GalaChainContext, data: ILockOnM
     .times(lockPercentage)
     .decimalPlaces(tokenClassEntry.decimals, BigNumber.ROUND_DOWN);
 
-  const verifyAuthorizedOnBehalf = async (c: TokenClassKey) => undefined;
+  const verifyAuthorizedOnBehalf = async () => undefined;
 
   // only support lock-on-mint postprocessing for fungibles, initially.
   // we would need to know a specific instance to lock for NFTs
@@ -186,8 +186,10 @@ export async function mintTokenWithAllowanceExitGate(
 export async function batchMintTokenExitGate(
   ctx: GalaChainContext,
   dto: BatchMintTokenDto,
-  response: GalaChainResponse<TokenInstanceKey[]>
+  _response: GalaChainResponse<TokenInstanceKey[]>
 ): Promise<void> {
+  void _response;
+
   for (const mintDto of dto.mintDtos) {
     const { tokenClass, quantity } = mintDto;
     const owner = mintDto.owner ?? ctx.callingUser;

--- a/chaincode/src/fees/feeGateImplementations.ts
+++ b/chaincode/src/fees/feeGateImplementations.ts
@@ -37,7 +37,6 @@ import {
   OraclePriceAssertion,
   OraclePriceCrossRateAssertion,
   PaymentRequiredError,
-  RequestTokenBridgeOutDto,
   TerminateTokenSwapDto,
   TokenClassKey,
   TokenInstanceKey,
@@ -88,7 +87,9 @@ export function extractUniqueUsersFromRequests(ctx: GalaChainContext, requests: 
   return Array.from(new Set(users));
 }
 
-export async function batchFillTokenSwapFeeGate(ctx: GalaChainContext, dto: BatchFillTokenSwapDto) {
+export async function batchFillTokenSwapFeeGate(ctx: GalaChainContext, _dto: BatchFillTokenSwapDto) {
+  void _dto;
+
   return galaFeeGate(ctx, { feeCode: FeeGateCodes.BatchFillTokenSwap });
 }
 
@@ -97,6 +98,8 @@ export async function batchMintTokenFeeGate(ctx: GalaChainContext, dto: BatchMin
   const owners: string[] = extractUniqueOwnersFromRequests(ctx, dto.mintDtos);
 
   for (const owner of owners) {
+    void owner;
+
     await galaFeeGate(ctx, {
       feeCode
       // v1 fees requires only callingUser identities pay fees
@@ -132,7 +135,9 @@ export async function batchMintTokenFeeGate(ctx: GalaChainContext, dto: BatchMin
   return Promise.resolve();
 }
 
-export async function burnTokensFeeGate(ctx: GalaChainContext, dto: BurnTokensDto) {
+export async function burnTokensFeeGate(ctx: GalaChainContext, _dto: BurnTokensDto) {
+  void _dto;
+
   return galaFeeGate(ctx, {
     feeCode: FeeGateCodes.BurnTokens
     // v1 fees requires only callingUser identities pay fees
@@ -140,7 +145,9 @@ export async function burnTokensFeeGate(ctx: GalaChainContext, dto: BurnTokensDt
   });
 }
 
-export async function terminateTokenSwapFeeGate(ctx: GalaChainContext, dto: TerminateTokenSwapDto) {
+export async function terminateTokenSwapFeeGate(ctx: GalaChainContext, _dto: TerminateTokenSwapDto) {
+  void _dto;
+
   return galaFeeGate(ctx, { feeCode: FeeGateCodes.TerminateTokenSwap });
 }
 
@@ -413,7 +420,9 @@ export async function requestTokenBridgeOutFeeGate(
   await putChainObject(ctx, bridgeFeeAssertionRecord);
 }
 
-export async function transferTokenFeeGate(ctx: GalaChainContext, dto: TransferTokenDto) {
+export async function transferTokenFeeGate(ctx: GalaChainContext, _dto: TransferTokenDto) {
+  void _dto;
+
   return galaFeeGate(ctx, {
     feeCode: FeeGateCodes.TransferToken
     // v1 fees requires only callingUser identities pay fees
@@ -423,11 +432,15 @@ export async function transferTokenFeeGate(ctx: GalaChainContext, dto: TransferT
   });
 }
 
-export async function galaSwapRequestFeeGate(ctx: GalaChainContext, dto: ChainCallDTO) {
+export async function galaSwapRequestFeeGate(ctx: GalaChainContext, _dto: ChainCallDTO) {
+  void _dto;
+
   return galaFeeGate(ctx, { feeCode: FeeGateCodes.SwapTokenRequest });
 }
 
-export async function galaSwapFillFeeGate(ctx: GalaChainContext, dto: FillTokenSwapDto) {
+export async function galaSwapFillFeeGate(ctx: GalaChainContext, _dto: FillTokenSwapDto) {
+  void _dto;
+
   return galaFeeGate(ctx, { feeCode: FeeGateCodes.SwapTokenFill });
 }
 
@@ -437,7 +450,9 @@ export async function galaSwapBatchFillFeeGate(ctx: GalaChainContext, dto: Batch
   }
 }
 
-export async function simpleFeeGate(ctx: GalaChainContext, dto: ChainCallDTO) {
+export async function simpleFeeGate(ctx: GalaChainContext, _dto: ChainCallDTO) {
+  void _dto;
+
   // example quick implementation fee gate
   // no need to write FeeCodeDefinitions or lookup FeeCodeDefinition objects to calc amount
   // tradeoff is its not flexible to update or modify, and won't record usage

--- a/chaincode/src/fees/fetchFeeAuthorizations.ts
+++ b/chaincode/src/fees/fetchFeeAuthorizations.ts
@@ -12,13 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  ChainError,
-  ErrorCode,
-  FeeAuthorization,
-  FetchFeeAuthorizationsResDto,
-  NotFoundError
-} from "@gala-chain/api";
+import { FeeAuthorization, FetchFeeAuthorizationsResDto } from "@gala-chain/api";
 
 import { GalaChainContext } from "../types";
 import { getObjectsByPartialCompositeKeyWithPagination, takeUntilUndefined } from "../utils";

--- a/chaincode/src/fees/fetchFeeBalances.ts
+++ b/chaincode/src/fees/fetchFeeBalances.ts
@@ -13,12 +13,9 @@
  * limitations under the License.
  */
 import {
-  ChainError,
-  ErrorCode,
   FeePendingBalance,
   FeePendingBalanceKeyValueResult,
-  FetchFeePendingBalancesResDto,
-  NotFoundError
+  FetchFeePendingBalancesResDto
 } from "@gala-chain/api";
 import { plainToInstance } from "class-transformer";
 

--- a/chaincode/src/fees/fetchFeeCreditReceipts.ts
+++ b/chaincode/src/fees/fetchFeeCreditReceipts.ts
@@ -13,12 +13,9 @@
  * limitations under the License.
  */
 import {
-  ChainError,
-  ErrorCode,
   FeeBalanceCreditReceipt,
   FeeCreditReceiptKeyValueResult,
-  FetchFeeCreditReceiptsResponse,
-  NotFoundError
+  FetchFeeCreditReceiptsResponse
 } from "@gala-chain/api";
 import { plainToInstance } from "class-transformer";
 

--- a/chaincode/src/fees/fetchFeePayments.ts
+++ b/chaincode/src/fees/fetchFeePayments.ts
@@ -13,12 +13,9 @@
  * limitations under the License.
  */
 import {
-  ChainError,
-  ErrorCode,
   FeeChannelPaymentKeyValueResult,
   FeeChannelPaymentReceipt,
-  FetchFeeChannelPaymentsResDto,
-  NotFoundError
+  FetchFeeChannelPaymentsResDto
 } from "@gala-chain/api";
 import { plainToInstance } from "class-transformer";
 

--- a/chaincode/src/fees/fetchFeeSchedule.ts
+++ b/chaincode/src/fees/fetchFeeSchedule.ts
@@ -12,13 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  ChainError,
-  ErrorCode,
-  FeeCodeDefinition,
-  FetchFeeScheduleResDto,
-  NotFoundError
-} from "@gala-chain/api";
+import { FeeCodeDefinition, FetchFeeScheduleResDto } from "@gala-chain/api";
 import BigNumber from "bignumber.js";
 
 import { GalaChainContext } from "../types";

--- a/chaincode/src/fees/payFeeFromCrossChannelAuthorization.ts
+++ b/chaincode/src/fees/payFeeFromCrossChannelAuthorization.ts
@@ -59,7 +59,7 @@ export async function payFeeFromCrossChannelAuthorization(ctx: GalaChainContext,
   pendingBalance.quantity = pendingBalance.quantity.minus(paymentRequired);
   await putChainObject(ctx, pendingBalance);
 
-  const { year, month, day, minutes, seconds } = txUnixTimeToDateIndexKeys(ctx.txUnixTime);
+  const { year, month, day } = txUnixTimeToDateIndexKeys(ctx.txUnixTime);
   const { feeCode, quantity } = data;
   const txId = ctx.stub.getTxID();
 

--- a/chaincode/src/fees/payFeeImmediatelyFromBalance.ts
+++ b/chaincode/src/fees/payFeeImmediatelyFromBalance.ts
@@ -102,7 +102,7 @@ export async function payFeeImmediatelyFromBalance(ctx: GalaChainContext, data: 
     });
   }
 
-  const { year, month, day, minutes, seconds } = txUnixTimeToDateIndexKeys(ctx.txUnixTime);
+  const { year, month, day } = txUnixTimeToDateIndexKeys(ctx.txUnixTime);
   const txId = ctx.stub.getTxID();
 
   // channel payment receipt and user payment receipts

--- a/chaincode/src/fees/splitFeeBurnAndTransfer.ts
+++ b/chaincode/src/fees/splitFeeBurnAndTransfer.ts
@@ -38,7 +38,7 @@ export async function splitFeeImmediatelyWithBurnAndTransfer(
   data: SplitFeeBurnAndTransferParams
 ): Promise<void> {
   const payingUser = ctx.callingUser;
-  const { feeCode, galaCurrencyKey, splitFormula } = data;
+  const { galaCurrencyKey, splitFormula } = data;
   const totalFeeQuantity = data.quantity;
 
   const { collection, category, type, additionalKey } = galaCurrencyKey;

--- a/chaincode/src/swaps/terminateTokenSwap.ts
+++ b/chaincode/src/swaps/terminateTokenSwap.ts
@@ -51,7 +51,7 @@ export async function terminateTokenSwap(
       name: tokenSwap.getCompositeKey(),
       quantity: instanceQuantity.quantity.times(tokenSwap.uses.minus(tokenSwap.usesSpent)),
       owner: tokenSwap.offeredBy
-    }).catch((e) => {
+    }).catch(() => {
       chainValidationErrors.push(
         `UnlockToken() failed for token ${instanceQuantity.tokenInstance.toStringKey()}, ` +
           `callingUser: ${ctx.callingUser}, swap: ${tokenSwap.getCompositeKey()}`

--- a/chaincode/src/vesting/vestingToken.ts
+++ b/chaincode/src/vesting/vestingToken.ts
@@ -16,7 +16,6 @@ import {
   Allocation,
   ChainObject,
   TokenBalance,
-  TokenClass,
   TokenClassKey,
   TokenInstance,
   TokenInstanceKey,
@@ -27,7 +26,6 @@ import {
 import BigNumber from "bignumber.js";
 import { plainToInstance } from "class-transformer";
 
-import { fetchBalances } from "../balances";
 import { lockToken } from "../locks";
 import { MintTokenWithAllowanceParams, mintTokenWithAllowance } from "../mint";
 import { CreateTokenClassParams, createTokenClass } from "../token";
@@ -118,7 +116,7 @@ export async function createVestingToken(
   const tokenClassParams: CreateTokenClassParams = {
     ...params
   };
-  const tokenClassResponse = await createTokenClass(ctx, tokenClassParams);
+  await createTokenClass(ctx, tokenClassParams);
 
   const tokenInstanceKey = plainToInstance(TokenInstanceKey, {
     ...params.tokenClass,
@@ -136,7 +134,7 @@ export async function createVestingToken(
       owner: allocation.owner,
       quantity: allocation.quantity
     };
-    const mintResponse = await mintTokenWithAllowance(ctx, mintParams);
+    await mintTokenWithAllowance(ctx, mintParams);
 
     let vestingPeriodStart = params.startDate;
     let expires = vestingPeriodStart;
@@ -156,7 +154,7 @@ export async function createVestingToken(
       };
     };
 
-    const lockResponse = await lockToken(ctx, {
+    await lockToken(ctx, {
       owner: allocation.owner,
       lockAuthority: ctx.callingUser,
       tokenInstanceKey,


### PR DESCRIPTION
## Summary
- remove unused imports and destructured values across chaincode fee helpers and fetchers
- mark intentionally ignored parameters in fee gates and exit gates to satisfy lint configuration
- drop unused vesting token responses to quiet eslint `no-unused-vars` warnings

## Testing
- CI=1 npx nx run chaincode:lint --files chaincode/src/fees/exitGateImplementations.ts,chaincode/src/fees/feeGateImplementations.ts,chaincode/src/fees/fetchFeeAuthorizations.ts,chaincode/src/fees/fetchFeeBalances.ts,chaincode/src/fees/fetchFeeCreditReceipts.ts,chaincode/src/fees/fetchFeePayments.ts,chaincode/src/fees/fetchFeeSchedule.ts,chaincode/src/fees/payFeeFromCrossChannelAuthorization.ts,chaincode/src/fees/payFeeImmediatelyFromBalance.ts,chaincode/src/fees/splitFeeBurnAndTransfer.ts,chaincode/src/swaps/terminateTokenSwap.ts,chaincode/src/vesting/vestingToken.ts

------
https://chatgpt.com/codex/tasks/task_e_68c85d5c52e083308aea7dafa09938f4