### PR TITLE
fix(chain-connect): allow arbitrary metamask events

### DIFF
--- a/chain-connect/src/helpers.ts
+++ b/chain-connect/src/helpers.ts
@@ -59,6 +59,8 @@ export interface MetaMaskEvents {
   accountChanged: string | null;
   /** Fired when the list of accounts changes */
   accountsChanged: string[] | null;
+  /** Catch-all signature to support additional wallet events */
+  [event: string]: string | string[] | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an index signature to the MetaMaskEvents interface so additional wallet events are accepted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86b626b50833085543524c5ec9690