### PR TITLE
chore(chain-api): ignore built files in tests

### DIFF
--- a/chain-api/jest.config.ts
+++ b/chain-api/jest.config.ts
@@ -21,6 +21,7 @@ export default {
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
   },
+  transformIgnorePatterns: ['<rootDir>/lib/'],
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../coverage/chain-api'
 };


### PR DESCRIPTION
## Summary
- update the chain-api Jest config to ignore prebuilt files under lib so ts-jest no longer transforms them

## Testing
- ./node_modules/.bin/nx test chain-api > /tmp/nx-test.log 2>&1


------
https://chatgpt.com/codex/tasks/task_e_68c8f1bad9ac8330937e2ee1248421aa