### PR TITLE
Fix chain-test e2e to run with mocked network

### DIFF
--- a/chain-test/jest.config.ts
+++ b/chain-test/jest.config.ts
@@ -25,6 +25,7 @@ export default {
   displayName: "chain-test",
   preset: "../jest.preset.js",
   testEnvironment: "node",
+  setupFiles: ["<rootDir>/jest.setup.ts"],
   transform: {
     "^.+\\.ts$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },

--- a/chain-test/jest.setup.ts
+++ b/chain-test/jest.setup.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const networkRoot =
+  process.env.GALA_NETWORK_ROOT_PATH ?? path.resolve(__dirname, "../chain-cli/network");
+
+process.env.GALA_NETWORK_ROOT_PATH = networkRoot;
+process.env.LOG_LEVEL = process.env.LOG_LEVEL ?? "error";
+
+const mockedChaincodeDir = path.resolve(__dirname, "mock-network");
+
+for (const key of [
+  "CURATORORG_MOCKED_CHAINCODE_DIR",
+  "USERSORG1_MOCKED_CHAINCODE_DIR",
+  "PARTNERORG1_MOCKED_CHAINCODE_DIR"
+]) {
+  if (process.env[key] === undefined) {
+    process.env[key] = mockedChaincodeDir;
+  }
+}
+
+if (process.env.DEV_ADMIN_PRIVATE_KEY === undefined) {
+  const adminKeyPath = path.resolve(networkRoot, "dev-admin-key/dev-admin.priv.hex.txt");
+
+  try {
+    const key = fs.readFileSync(adminKeyPath, "utf8").trim();
+    if (key.length > 0) {
+      process.env.DEV_ADMIN_PRIVATE_KEY = key;
+    }
+  } catch {
+    // Fallback to the default development key used by the mock network fixtures.
+    process.env.DEV_ADMIN_PRIVATE_KEY = "62172f65ecab45f423f7088128eee8946c5b3c03911cb0b061b1dd9032337271";
+  }
+}

--- a/chain-test/mock-network/index.js
+++ b/chain-test/mock-network/index.js
@@ -1,0 +1,73 @@
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const tsnode = require("ts-node");
+const tsConfigPaths = require("tsconfig-paths");
+
+const compilerOptions = {
+  module: "commonjs",
+  moduleResolution: "node",
+  target: "es2019",
+  esModuleInterop: true,
+  emitDecoratorMetadata: true,
+  experimentalDecorators: true,
+  baseUrl: path.resolve(__dirname, "../.."),
+  paths: {
+    "@gala-chain/api": ["chain-api/src/index.ts"],
+    "@gala-chain/chaincode": ["chaincode/src/index.ts"],
+    "@gala-chain/cli": ["chain-cli/src/index.ts"],
+    "@gala-chain/client": ["chain-client/src/index.ts"],
+    "@gala-chain/connect": ["chain-connect/src/index.ts"],
+    "@gala-chain/test": ["chain-test/src/index.ts"]
+  },
+  moduleSuffixes: [".ts", ".tsx", ".d.ts", ".js", ""]
+};
+
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (
+    typeof request === "string" &&
+    parent &&
+    (request.startsWith("./") || request.startsWith("../")) &&
+    request.endsWith(".js")
+  ) {
+    try {
+      return originalResolveFilename.call(this, request, parent, isMain, options);
+    } catch (err) {
+      const candidate = path.resolve(path.dirname(parent.filename), request);
+      const tsCandidate = candidate.replace(/\.js$/, ".ts");
+      if (fs.existsSync(tsCandidate)) {
+        return originalResolveFilename.call(this, tsCandidate, parent, isMain, options);
+      }
+    }
+  }
+
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+// Register ts-node so that TypeScript contracts can be loaded on demand.
+tsnode.register({
+  transpileOnly: true,
+  compilerOptions
+});
+
+// Ensure TypeScript path aliases resolve correctly when requiring modules.
+tsConfigPaths.register({
+  baseUrl: compilerOptions.baseUrl,
+  paths: compilerOptions.paths
+});
+
+require("reflect-metadata");
+
+const { PublicKeyContract } = require(path.resolve(
+  __dirname,
+  "../../chaincode/src/contracts/PublicKeyContract"
+));
+const GalaChainTokenContract = require(path.resolve(
+  __dirname,
+  "../../chaincode/src/__test__/GalaChainTokenContract"
+)).default;
+
+module.exports = {
+  contracts: [PublicKeyContract, GalaChainTokenContract]
+};

--- a/chain-test/mock-network/package.json
+++ b/chain-test/mock-network/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@gala-chain/mock-network",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "index.js"
+}

--- a/chain-test/src/e2e/MockedChaincodeClient.ts
+++ b/chain-test/src/e2e/MockedChaincodeClient.ts
@@ -28,6 +28,8 @@ import path from "path";
 
 import { TestChaincode } from "../unit";
 
+import { seedDefaultMockState } from "./mockState";
+
 /**
  * Mocked chaincode client implementation for testing.
  *
@@ -145,6 +147,7 @@ export class MockedChaincodeClientBuilder implements ChainClientBuilder {
         throw new Error(`Contract ${config.contract} not found in ${this.mockedChaincodeDir}`);
       }
       const state = getOrCreateState(config.channel, config.chaincode);
+      seedDefaultMockState(state);
       return new TestChaincode([contract], state, {}, this.adminId, this.orgMsp);
     });
     return new MockedChaincodeClient(this, chaincode, config, this.orgMsp, this.adminId);

--- a/chain-test/src/e2e/mockState.ts
+++ b/chain-test/src/e2e/mockState.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChainUser, SigningScheme, signatures, UserProfile } from "@gala-chain/api";
+
+function getAdminUser(): ChainUser | undefined {
+  const privateKey = process.env.DEV_ADMIN_PRIVATE_KEY;
+
+  if (!privateKey) {
+    return undefined;
+  }
+
+  return new ChainUser({ name: "admin", privateKey });
+}
+
+const PUBLIC_KEY_PREFIX = "\u0000GCPK\u0000";
+const USER_PROFILE_PREFIX = "\u0000GCUP\u0000";
+
+function normalizePublicKey(publicKey: string): string {
+  return signatures.normalizePublicKey(publicKey).toString("base64");
+}
+
+/**
+ * Seeds the provided chaincode state with default identities required by mocked tests.
+ *
+ * Currently this registers the development admin user so that contract calls requiring
+ * registrar permissions behave the same way as in a bootstrapped network.
+ */
+export function seedDefaultMockState(state: Record<string, string>) {
+  const adminUser = getAdminUser();
+
+  if (!adminUser) {
+    return;
+  }
+
+  const adminPkKey = `${PUBLIC_KEY_PREFIX}${adminUser.identityKey}\u0000`;
+  if (state[adminPkKey] === undefined) {
+    const normalized = normalizePublicKey(adminUser.publicKey);
+    state[adminPkKey] = JSON.stringify({
+      publicKey: normalized,
+      publicKeys: [normalized],
+      requiredSignatures: 1,
+      signing: SigningScheme.ETH
+    });
+  }
+
+  const adminProfileKey = `${USER_PROFILE_PREFIX}${adminUser.ethAddress}\u0000`;
+  if (state[adminProfileKey] === undefined) {
+    state[adminProfileKey] = JSON.stringify({
+      alias: adminUser.identityKey,
+      ethAddress: adminUser.ethAddress,
+      roles: [...UserProfile.ADMIN_ROLES],
+      pubKeyCount: 1,
+      requiredSignatures: 1
+    });
+  }
+}

--- a/chain-test/src/e2e/multisig.spec.ts
+++ b/chain-test/src/e2e/multisig.spec.ts
@@ -15,6 +15,7 @@
 import {
   GetMyProfileDto,
   RegisterUserDto,
+  SigningScheme,
   UserAlias,
   createValidSubmitDTO,
   signatures
@@ -42,7 +43,8 @@ describe("multisig e2e", () => {
 
     const regDto = await createValidSubmitDTO(RegisterUserDto, {
       user: alias,
-      publicKeys: [kp1.publicKey, kp2.publicKey]
+      publicKeys: [kp1.publicKey, kp2.publicKey],
+      signing: SigningScheme.ETH
     });
     const regResp = await client.pk.RegisterUser(regDto.signed(client.pk.privateKey));
     expect(regResp).toEqual(transactionSuccess());


### PR DESCRIPTION
## Summary
- add a Jest setup file that configures the mocked chaincode environment variables and dev admin key fallback
- load contracts from TypeScript sources in a local mock network and seed admin state for mocked chain clients
- ensure the multisig registration DTO specifies the ETH signing scheme used in tests

## Testing
- npx nx test chain-test

------
https://chatgpt.com/codex/tasks/task_e_68c8f81543948330a4f3a8f9dbc9fc59