### PR TITLE
Fix multisig signature verification

### DIFF
--- a/chaincode/src/contracts/authenticate.ts
+++ b/chaincode/src/contracts/authenticate.ts
@@ -23,6 +23,7 @@ import {
   convertLegacySignatures,
   signatures
 } from "@gala-chain/api";
+import { instanceToPlain } from "class-transformer";
 import * as protos from "fabric-protos";
 
 import { PkInvalidSignatureError, PublicKeyService } from "../services";
@@ -255,14 +256,12 @@ function recoverPublicKey(
     return undefined;
   }
 
-  const payload: Record<string, unknown> = {
-    ...dto,
-    signature: undefined,
-    signatures: undefined,
-    signerPublicKey: undefined,
-    signerAddress: undefined,
-    prefix: undefined
-  };
+  const payload = instanceToPlain(dto) as Record<string, unknown>;
+  payload.signature = undefined;
+  payload.signatures = undefined;
+  payload.signerPublicKey = undefined;
+  payload.signerAddress = undefined;
+  payload.prefix = undefined;
 
   if (scheme !== undefined) {
     payload.signing = scheme;


### PR DESCRIPTION
## Summary
- ensure signature recovery uses a class-transformer plain object so BigNumber fields match the signed payload

## Testing
- npx jest src/allowances/grantAllowance.spec.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d3163b71dc83309566eebc8520c4f8